### PR TITLE
Add Omni Scoreboard roadmap and agent context

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SessionStart hook: orient the agent with branch + working-tree status and point it at
+# the canonical docs. Read-only; safe. Referenced from .claude/settings.json.
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}" 2>/dev/null || exit 0
+b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+printf 'omni-scoreboard | branch %s\n' "${b:-?}"
+git status --short 2>/dev/null | head -6
+printf '%s\n' '-> read AGENTS.md (canonical map) and docs/agent_context/STATUS.md'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(uv:*)",
+      "Bash(.venv/bin/python:*)",
+      "Bash(.venv/bin/pytest:*)",
+      "Bash(.venv/bin/mypy:*)",
+      "Bash(.venv/bin/black:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(pytest:*)",
+      "Bash(mypy:*)",
+      "Bash(black:*)",
+      "Bash(ruff:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git branch:*)",
+      "Bash(git switch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git stash:*)",
+      "Bash(git fetch:*)",
+      "Bash(git remote:*)",
+      "Bash(git restore:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh repo list:*)",
+      "Bash(gh run:*)",
+      "Bash(gh browse:*)",
+      "Bash(gh auth status:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(tree:*)",
+      "Bash(which:*)",
+      "Bash(echo:*)",
+      "Bash(pwd)",
+      "Bash(diff:*)",
+      "Bash(jq:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(source:*)",
+      "WebFetch(domain:code.claude.com)",
+      "WebFetch(domain:docs.claude.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:statsapi.mlb.com)",
+      "WebFetch(domain:site.api.espn.com)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+      "Bash(git reset:*)",
+      "Bash(git revert:*)",
+      "Bash(git rm:*)",
+      "Bash(git clean:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(rm:*)",
+      "Bash(rmdir:*)",
+      "Bash(pip:*)",
+      "Bash(chmod:*)",
+      "Bash(chown:*)"
+    ],
+    "deny": [
+      "Bash(sudo:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push origin +*)",
+      "Bash(gh repo delete:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Read(~/config/.env)",
+      "Read(~/.config/alpine/**)",
+      "Read(~/.ssh/**)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/id_rsa*)",
+      "Read(**/id_ed25519)"
+    ]
+  },
+  "defaultMode": "acceptEdits",
+  "env": {
+    "PYTHONUNBUFFERED": "1",
+    "UV_PYTHON": "3.12"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/curate-knowledge/SKILL.md
+++ b/.claude/skills/curate-knowledge/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: curate-knowledge
+description: Maintain the project's agent-facing knowledge base in an ingestion-optimal shape — prune, dedupe, keep AGENTS.md a lean map and CLAUDE.md a thin wrapper, and keep local memory machine-local. Use periodically, when docs drift, or after a milestone.
+---
+
+# Curate the knowledge base
+
+Source of truth is **agent-agnostic and committed**: `AGENTS.md` (map) + `docs/agent_context/`
+(body) + `docs/agent_context/STATUS.md` (living status). `CLAUDE.md` and `.cursor/rules/` are
+THIN wrappers that defer to `AGENTS.md` — keep them thin.
+
+Run this maintenance pass to keep everything ingestion-optimal:
+
+1. **Update `STATUS.md`** whenever state changes (branch, PR, milestone). It should be short.
+2. **One concept per doc.** Keep `AGENTS.md` a lean map (links, not prose dumps).
+3. **Prune.** Delete docs/sections for shipped or abandoned work; remove stale commands;
+   collapse duplicates. Verify a referenced file/flag still exists before keeping the claim.
+4. **Promote.** A fact repeated >3× → put it in `AGENTS.md` or a doc. A procedure repeated >3×
+   → make it a skill in `.claude/skills/`.
+5. **Keep `CLAUDE.md`/`.cursor` thin.** If knowledge is creeping into them, move it to
+   `AGENTS.md`/`docs/` and leave a pointer.
+6. **Local auto-memory** (`~/.claude/projects/-opt-omni-scoreboard/memory/`) holds only
+   machine-specific facts and must point back to `AGENTS.md` — never let it override committed
+   docs. Keep `MEMORY.md` a short index; delete stale memory files.
+7. **Never** put secrets, tokens, or machine-local paths into committed docs.

--- a/.claude/skills/port-from-legacy/SKILL.md
+++ b/.claude/skills/port-from-legacy/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: port-from-legacy
+description: Selectively port pre-revival Omni work from the legacy fork as reference. Use when reviving a feature or behavior that existed in the old omni-scoreboard before the upstream-based reset.
+---
+
+# Port from legacy (reference only)
+
+The pre-revival Omni history is the `legacy` remote (`legacy/master`, `legacy/dev`). Per
+`AGENTS.md`: **do not blindly merge legacy into upstream** — treat it as reference/prototype.
+
+```bash
+git fetch legacy
+git log legacy/master --oneline           # find the feature/commit
+git show legacy/master:<path>             # inspect a file without checking it out
+git checkout legacy/master -- <path>      # pull a file into the tree to adapt (then re-type it)
+```
+
+Re-implement in the typed domain (`League`, `PanelProfile`, typed `ScoreboardCard`, etc.)
+rather than copying stringly-typed code. Provider JSON stays at the boundary; renderers stay
+data-free. Add tests for ported behavior.

--- a/.claude/skills/run-emulator/SKILL.md
+++ b/.claude/skills/run-emulator/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: run-emulator
+description: Run the Omni Scoreboard in the RGBMatrixEmulator (headless browser adapter) to see/verify rendering without Raspberry Pi hardware. Use when asked to run, start, screenshot, or visually check the scoreboard.
+---
+
+# Run the emulator
+
+Software emulation — no Pi hardware required. Canonical setup: `docs/dev_setup.md`.
+
+Ensure the project-local env exists (see `docs/dev_setup.md`):
+
+```bash
+uv venv .venv --python 3.12 && uv pip install -r requirements.txt   # first time only
+cp -n config.example.json config.json                                # seed local config (gitignored)
+```
+
+Run (browser adapter serves the panel at http://localhost:8888/):
+
+```bash
+.venv/bin/python main.py --emulated
+# Omni panel profiles via matrix flags, e.g. single_64x32:
+# .venv/bin/python main.py --emulated --led-cols 64 --led-rows 32
+```
+
+Non-interactive smoke test (bound it so it self-stops):
+
+```bash
+timeout 20 .venv/bin/python main.py --emulated
+```
+
+Exit 124 = it ran fine until the timeout. Confirm logs show the version banner, data fetch,
+and `Server started ... http://localhost:8888/`.

--- a/.claude/skills/run-on-board/SKILL.md
+++ b/.claude/skills/run-on-board/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: run-on-board
+description: Run, check, or attach to the Omni Scoreboard on the physical 2x2 (quad_128x64) Raspberry Pi board over SSH. Use when asked to deploy to, run on, restart, attach to, or check the real hardware panel.
+---
+
+# Run on the physical board (quad_128x64)
+
+There is a real 2x2 board (logical 128x64) on the LAN. **Its SSH target is machine-local** — it
+is the `omni-board` host alias in `~/.ssh/config`, documented in `CLAUDE.local.md` (both
+git-ignored / NOT in this public repo). Always use the alias, never a hardcoded IP, in
+committed files. Key-based SSH is set up, so commands can run non-interactively from WSL.
+
+Check status (read-only, safe — do this first):
+
+```bash
+ssh omni-board 'whoami; hostname; screen -list | grep -i omni || echo "(no omni session)"'
+```
+
+Attach to the live session (interactive):
+
+```bash
+ssh -t omni-board 'screen -x omni'
+```
+
+Start headless only if not already running (the canonical one-liner — launches the board's
+runner in a detached screen named `omni`):
+
+```bash
+ssh omni-board "screen -list | grep -q '\\.omni' && screen -x omni || screen -dmS omni bash -c 'cd ~/omni-scoreboard && ./run.sh'"
+```
+
+**Cautions**
+- This drives a PHYSICAL panel and is often already running — check first; never restart casually.
+- The board currently runs the **pre-revival** code at `~/omni-scoreboard` on the Pi via
+  `run.sh`. Deploying *this* revived repo to the board is future work (ROADMAP: safe updater).
+  Until then treat the board as the legacy/reference runtime for the 128x64 profile.
+- Stop a session intentionally (blanks the panel): `ssh omni-board 'screen -S omni -X quit'`.

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: sync-upstream
+description: Pull the latest MLB-LED-Scoreboard upstream into Omni and reconcile it. Use when updating to a new upstream release or catching up on upstream fixes.
+---
+
+# Sync from upstream
+
+Remotes: `origin` = `ajszoke/omni-scoreboard`, `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard`
+(branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy`.
+
+```bash
+git fetch upstream --tags
+git switch main
+git merge --no-ff upstream/master        # or rebase a feature branch onto upstream/master
+```
+
+After merging:
+- Re-check the typed-domain invariants and the three display profiles (`AGENTS.md`) — do not
+  let an upstream change regress them.
+- Run the `test` skill.
+- **Never force-push `main`.** Resolve conflicts in favor of Omni's typed domain at boundaries.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: test
+description: Run the Omni Scoreboard test suite plus type and style checks. Use before committing, when verifying a change, or when asked to run tests/lint/typecheck.
+---
+
+# Test, typecheck, format
+
+Run from the repo root with the project-local `.venv` (see `docs/dev_setup.md`):
+
+```bash
+.venv/bin/python -m pytest tests/ -v
+.venv/bin/python -m mypy .            # config in pyproject.toml
+.venv/bin/python -m black --check .   # line-length 120 (pyproject.toml)
+```
+
+`uv run pytest ...` etc. also work. New domain code must follow the typed-domain policy in
+`AGENTS.md` (no new stringly-typed league/team/event/card concepts). Add a fixture or
+golden-image snapshot test for every spacing/animation bug fixed.

--- a/.cursor/rules/omni-scoreboard.mdc
+++ b/.cursor/rules/omni-scoreboard.mdc
@@ -1,0 +1,40 @@
+---
+description: Omni Scoreboard project rules
+globs:
+  - "**/*.py"
+  - "**/*.md"
+  - "**/*.json"
+  - "**/*.yaml"
+alwaysApply: true
+---
+
+# Omni Scoreboard Cursor Rules
+
+This project is a friends-and-family LED sports scoreboard, not a consumer SaaS product.
+
+Support these display profiles equally:
+
+- `single_64x32`
+- `stack_64x64`
+- `quad_128x64`
+
+Typed/OOP policy:
+
+- Prefer strict typed objects over primitives in domain code.
+- Use `League`, `Team`/`BaseballTeam`, `PanelProfile`, sport-specific event enums, `DisplayTiming`, `CardPriority`, and typed card payloads.
+- Raw strings/dicts are acceptable only at API/config/fixture boundaries.
+- Provider modules convert raw API JSON into typed domain objects immediately.
+- Renderers consume typed `ScoreboardCard` payloads and never fetch data.
+
+Roadmap order:
+
+1. Clean upstream-based repo.
+2. Emulator and fixture replay.
+3. Typed domain core.
+4. Three display profiles.
+5. MLB polish and bug fixes.
+6. Generic TV-delay/interleaved card queue.
+7. Local setup/updater/device management.
+8. NFL, NBA, NHL, PGA, NCAA later.
+
+Do not add `v2` to repo/branch/product names unless it is a throwaway local branch.

--- a/.cursor/rules/omni-scoreboard.mdc
+++ b/.cursor/rules/omni-scoreboard.mdc
@@ -8,33 +8,18 @@ globs:
 alwaysApply: true
 ---
 
-# Omni Scoreboard Cursor Rules
+# Omni Scoreboard — Cursor rules
 
-This project is a friends-and-family LED sports scoreboard, not a consumer SaaS product.
+The canonical, agent-agnostic project guide is **`AGENTS.md`** at the repo root — follow it.
+This file is a thin wrapper restating only the non-negotiable invariants:
 
-Support these display profiles equally:
+- Friends-and-family LED scoreboard (not a consumer product). Support three panel profiles
+  **equally**: `single_64x32`, `stack_64x64`, `quad_128x64`.
+- Typed domain: `League`, `Team`/`BaseballTeam`, `PanelProfile`, sport event enums,
+  `DisplayTiming`, `CardPriority`, typed `ScoreboardCard`. Raw strings/dicts only at
+  API/config/fixture boundaries. Provider modules convert to typed objects immediately;
+  renderers consume typed cards and never fetch.
+- Build on current upstream MLB-LED-Scoreboard; legacy is reference only. No `v2` in
+  repo/branch/product names.
 
-- `single_64x32`
-- `stack_64x64`
-- `quad_128x64`
-
-Typed/OOP policy:
-
-- Prefer strict typed objects over primitives in domain code.
-- Use `League`, `Team`/`BaseballTeam`, `PanelProfile`, sport-specific event enums, `DisplayTiming`, `CardPriority`, and typed card payloads.
-- Raw strings/dicts are acceptable only at API/config/fixture boundaries.
-- Provider modules convert raw API JSON into typed domain objects immediately.
-- Renderers consume typed `ScoreboardCard` payloads and never fetch data.
-
-Roadmap order:
-
-1. Clean upstream-based repo.
-2. Emulator and fixture replay.
-3. Typed domain core.
-4. Three display profiles.
-5. MLB polish and bug fixes.
-6. Generic TV-delay/interleaved card queue.
-7. Local setup/updater/device management.
-8. NFL, NBA, NHL, PGA, NCAA later.
-
-Do not add `v2` to repo/branch/product names unless it is a throwaway local branch.
+See `AGENTS.md` for the full map, current status, roadmap order, and dev setup.

--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,9 @@ team_colors.jpg
 
 # Editors
 .vscode/
-.claude/
+
+# Claude Code: commit SHARED project config (.claude/settings.json, skills/, commands/,
+# agents/); keep personal/local overrides out of git.
+.claude/settings.local.json
+.claude/*.local.json
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — Omni Scoreboard
+
+Read this first before changing code.
+
+## Project intent
+
+Omni Scoreboard is a friends-and-family LED sports scoreboard. It is not a full consumer SaaS/product company.
+
+Prioritize reliability, local setup, typed code, fixture replay, and delightful small-display behavior over feature sprawl.
+
+## Supported displays
+
+All significant UI work must consider these three profiles equally:
+
+- `single_64x32`: 1x1 64x32 panel.
+- `stack_64x64`: 2x1 vertical stack of two 64x32 panels, logical 64x64.
+- `quad_128x64`: 2x2 matrix, logical 128x64.
+
+A feature may compromise by profile, but the compromise must be explicit and tested.
+
+## Repo posture
+
+The revived repo should use `omni-scoreboard`, not `omni-scoreboard-v2` or similar.
+
+The old fork should be preserved as `omni-scoreboard-legacy`. The new repo should be based on current upstream `MLB-LED-Scoreboard/mlb-led-scoreboard`, with old Omni work ported selectively.
+
+Do not blindly merge the legacy fork into upstream. Use legacy code as reference/prototype material.
+
+## Immediate priorities
+
+1. Stand up clean repo/local clone.
+2. Run upstream in emulator.
+3. Add typed enum/domain foundation.
+4. Add display profile model for 64x32, 64x64, 128x64.
+5. Add fixture replay and snapshot tests.
+6. Fix MLB P0/P1 bugs before broad league expansion.
+7. Implement generic delay/event/card queue.
+8. Add setup portal, safe updater, sleep schedule, and physical button support.
+9. Add NFL, NBA, NHL, PGA, then NCAA later.
+
+## Type policy
+
+Do not introduce new raw stringly-typed league/team/event/card concepts.
+
+Use typed enums and frozen/slotted dataclasses:
+
+- `League`, not `"mlb"`.
+- `BaseballTeam`, not `"COL"`.
+- `BaseballGameEventType.HOME_RUN`, not `"home_run"`.
+- `PanelProfile.SINGLE_64X32`, not `(64, 32)`.
+- `DisplayTiming`, not loose `available_at`, `expires_at`, `min_seconds`, `max_seconds` primitives scattered across code.
+
+Raw JSON may exist only in provider boundary modules and fixtures.
+
+## Rendering policy
+
+Renderers should consume typed `ScoreboardCard` payloads and a `PanelProfile`. They should not fetch data. They should not parse provider JSON. They should not own TV-delay semantics.
+
+Every spacing/animation bug fixed should get a fixture or golden-image snapshot test.
+
+## Data policy
+
+Free/low-cost by default:
+
+- MLB: upstream MLB StatsAPI integration.
+- NFL/NBA/NHL/PGA initial spike: ESPN site APIs, isolated behind provider interfaces.
+- PGA probability/cut-line optional: DataGolf if worth the key/cost.
+- Commercial fallback only after free sources fail product needs.
+
+## Device policy
+
+For friends/family units:
+
+- Local Wi-Fi setup portal, not mobile app.
+- Safe `systemd` updater with rollback, not cron `git pull`.
+- Local config and credentials.
+- Sleep/wake schedule.
+- Physical switch/button support.
+- Avoid cloud dependencies.
+
+## Never do these without explicit human approval
+
+- Delete or force-push legacy branches.
+- Rewrite published history on `main`.
+- Add paid data/API dependency as required default.
+- Add user accounts/cloud backend.
+- Drop support for any of the three display profiles.
+- Commit secrets, Wi-Fi credentials, or API keys.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,24 @@ Omni Scoreboard is a friends-and-family LED sports scoreboard. It is not a full 
 
 Prioritize reliability, local setup, typed code, fixture replay, and delightful small-display behavior over feature sprawl.
 
+## Status & repository map
+
+This file is the **single, agent-agnostic source of truth**. Tool-specific configs are thin
+wrappers that defer here: `CLAUDE.md` (Claude Code) and `.cursor/rules/` (Cursor). Harness
+config (permissions/skills) lives in `.claude/` but carries no project knowledge.
+
+- **Current status:** `docs/agent_context/STATUS.md` (living — update when state changes).
+- **Deep context:** `docs/agent_context/` — `ROADMAP.md`, `ARCHITECTURE_TYPED_DOMAIN.md`, `BACKLOG.yaml`, `SOURCES.md`.
+- **Dev environment:** uv + project-local `.venv`; software emulator, no Pi needed — `docs/dev_setup.md`.
+- **Code:** `main.py` (entry), `renderers/`, `data/`, local packages `bullpen/ standings/ news/`; `starter_code/` holds typed-domain sketches to grow into `omni/`.
+- **Reference hardware:** a physical `quad_128x64` (2×2) board runs headless on the LAN (`screen` + `run.sh`); its SSH target is machine-local (`CLAUDE.local.md`, git-ignored). Use the `run-on-board` skill. It currently runs the pre-revival code.
+
+## Operating notes
+
+- **Commit identity:** author as `ajszoke <aszoke1@gmail.com>`, set **repo-local** (not global). Push over **HTTPS + `gh`** — SSH may resolve to a different GitHub identity on some machines. Never force-push `main`.
+- **Never commit:** secrets, `config.json`, `emulator_config.json`, `.venv/`, build artifacts/caches.
+- **Knowledge-base hygiene (keep it ingestion-optimal):** one concept per doc; keep this map lean (links, not prose dumps); prune docs for shipped/abandoned work; promote a thrice-repeated fact into a doc and a repeated procedure into a `.claude/skills/` skill; verify a referenced file/flag still exists before relying on it. Claude Code's machine-local auto-memory supplements but never overrides these committed docs.
+
 ## Supported displays
 
 All significant UI work must consider these three profiles equally:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md — Omni Scoreboard (Claude Code entry point)
+
+This is a **thin, Claude-Code-specific wrapper**. The canonical, agent-agnostic project
+guide is **`AGENTS.md`** — read it first. Put durable knowledge in `AGENTS.md` / `docs/`,
+**not** here; keep this file thin.
+
+@AGENTS.md
+
+## Claude Code specifics (not in AGENTS.md)
+
+- **Harness config** lives in `.claude/`: a permissions allowlist + a SessionStart status
+  hook (`settings.json`) and workflow skills (`skills/`). Personal, uncommitted overrides go
+  in `.claude/settings.local.json` and `CLAUDE.local.md` (both git-ignored).
+- **Where to look:** current status → `docs/agent_context/STATUS.md`; dev env & emulator →
+  `docs/dev_setup.md`; roadmap/architecture/backlog → `docs/agent_context/`.
+- **Local auto-memory** (`~/.claude/projects/-opt-omni-scoreboard/memory/`) supplements a
+  session but **never overrides** the committed docs above — `AGENTS.md` + `docs/` are the
+  source of truth. Keep memory pruned and machine-local-only (see the `curate-knowledge` skill).

--- a/docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md
+++ b/docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md
@@ -1,0 +1,588 @@
+# Omni Scoreboard Typed Domain Architecture
+
+## Guiding principle
+
+Raw primitives belong at the boundaries only: config JSON, provider JSON, CLI args, and file paths. Inside the application, domain concepts should be typed objects that own their own concerns.
+
+Examples:
+
+- Do not pass `"mlb"`; pass `League.MLB`.
+- Do not pass `"COL"`; pass a `BaseballTeam` or `TeamId` resolved by the registry.
+- Do not pass `"home_run"`; pass `BaseballGameEventType.HOME_RUN`.
+- Do not pass `(64, 32)`; pass `DisplayProfile.SINGLE_64X32` or a `PanelGeometry` object.
+- Do not pass loose priority floats everywhere; pass `DisplayPriority`/`PriorityScore` with reason codes.
+
+## Enum policy
+
+Crib the uploaded enum approach in spirit and implementation:
+
+- `StrEnumMixin` for string-valued identifiers where the value is canonical and JSON-safe.
+- `IntEnumMixin` for ordered severities/urgencies/priorities where comparison is meaningful.
+- `try_coerce_enum()` for tolerant fixture/replay/config readers.
+- Strict construction paths should fail fast; tolerant paths should only be used for debugging/replay/migration.
+
+Recommended initial enum module: `omni/core/enum.py`.
+
+## Package layout
+
+```text
+omni/
+  core/
+    enum.py
+    ids.py
+    time.py
+    colors.py
+    serialization.py
+  domain/
+    base.py
+    teams.py
+    athletes.py
+    baseball.py
+    football.py
+    basketball.py
+    hockey.py
+    golf.py
+  events/
+    base.py
+    baseball.py
+    football.py
+    basketball.py
+    hockey.py
+    golf.py
+  cards/
+    base.py
+    baseball.py
+    football.py
+    basketball.py
+    hockey.py
+    golf.py
+  queue/
+    delay_buffer.py
+    priority.py
+    scheduler.py
+  panels/
+    profiles.py
+    geometry.py
+    layout_contract.py
+  providers/
+    base.py
+    mlb_statsapi.py
+    espn.py
+    datagolf.py
+    sportsdataio.py
+  renderers/
+    base.py
+    profile_single_64x32.py
+    profile_stack_64x64.py
+    profile_quad_128x64.py
+  preview/
+    fixture_replay.py
+    snapshot.py
+    web.py
+```
+
+This can be introduced incrementally inside the upstream tree. Do not attempt a giant rewrite before the emulator works.
+
+## Core enums
+
+```python
+from enum import Enum, IntEnum
+from omni.core.enum import StrEnumMixin, IntEnumMixin
+
+class Sport(StrEnumMixin, str, Enum):
+    BASEBALL = "baseball"
+    FOOTBALL = "football"
+    BASKETBALL = "basketball"
+    HOCKEY = "hockey"
+    GOLF = "golf"
+
+class League(StrEnumMixin, str, Enum):
+    MLB = "mlb"
+    NFL = "nfl"
+    NBA = "nba"
+    NHL = "nhl"
+    PGA = "pga"
+    NCAAF = "ncaaf"
+    NCAAB = "ncaab"
+
+    @property
+    def sport(self) -> Sport:
+        return {
+            League.MLB: Sport.BASEBALL,
+            League.NFL: Sport.FOOTBALL,
+            League.NBA: Sport.BASKETBALL,
+            League.NHL: Sport.HOCKEY,
+            League.PGA: Sport.GOLF,
+            League.NCAAF: Sport.FOOTBALL,
+            League.NCAAB: Sport.BASKETBALL,
+        }[self]
+
+class PanelProfile(StrEnumMixin, str, Enum):
+    SINGLE_64X32 = "single_64x32"
+    STACK_64X64 = "stack_64x64"
+    QUAD_128X64 = "quad_128x64"
+
+class GameStatus(StrEnumMixin, str, Enum):
+    SCHEDULED = "scheduled"
+    PREGAME = "pregame"
+    LIVE = "live"
+    DELAYED = "delayed"
+    SUSPENDED = "suspended"
+    FINAL = "final"
+    POSTPONED = "postponed"
+    CANCELED = "canceled"
+    UNKNOWN = "unknown"
+
+class DisplayPriority(IntEnumMixin, IntEnum):
+    BACKGROUND = 0
+    NORMAL = 10
+    FAVORITE = 20
+    HIGH_LEVERAGE = 30
+    ALERT = 40
+    STICKY = 50
+
+class UpdateUrgency(IntEnumMixin, IntEnum):
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    LIVE_CRITICAL = 3
+```
+
+## Event type enums
+
+Keep event type enums sport-specific. A baseball event and a football event may both be “score”, but the downstream concerns are different.
+
+```python
+class BaseballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    PITCH = "pitch"
+    BALL = "ball"
+    CALLED_STRIKE = "called_strike"
+    SWINGING_STRIKE = "swinging_strike"
+    FOUL = "foul"
+    BALL_IN_PLAY = "ball_in_play"
+    STRIKEOUT_LOOKING = "strikeout_looking"
+    STRIKEOUT_SWINGING = "strikeout_swinging"
+    WALK = "walk"
+    HIT_BY_PITCH = "hit_by_pitch"
+    SINGLE = "single"
+    DOUBLE = "double"
+    TRIPLE = "triple"
+    HOME_RUN = "home_run"
+    SAC_FLY = "sac_fly"
+    SAC_BUNT = "sac_bunt"
+    DOUBLE_PLAY = "double_play"
+    TRIPLE_PLAY = "triple_play"
+    RUN_SCORED = "run_scored"
+    RBI = "rbi"
+    PITCHING_CHANGE = "pitching_change"
+    CHALLENGE = "challenge"
+    ABS_CHALLENGE = "abs_challenge"
+    INNING_START = "inning_start"
+    HALF_INNING_END = "half_inning_end"
+    GAME_FINAL = "game_final"
+    NO_HITTER_ACTIVE = "no_hitter_active"
+    NO_HITTER_BROKEN = "no_hitter_broken"
+    PERFECT_GAME_ACTIVE = "perfect_game_active"
+    PERFECT_GAME_BROKEN = "perfect_game_broken"
+```
+
+NFL/NBA/NHL/PGA should get parallel sport-specific enums, not a giant universal enum.
+
+## Value object policy
+
+Use frozen, slotted dataclasses for durable domain values.
+
+```python
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from typing import Final
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    name: str              # e.g. "mlb_statsapi", "espn", "datagolf"
+    raw_url: str | None = None
+
+@dataclass(frozen=True, slots=True)
+class LeagueScopedId:
+    league: League
+    source: SourceRef
+    raw: str
+
+    def __str__(self) -> str:
+        return f"{self.league}:{self.source.name}:{self.raw}"
+
+@dataclass(frozen=True, slots=True)
+class DurationSeconds:
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError("duration cannot be negative")
+
+    def as_timedelta(self) -> timedelta:
+        return timedelta(seconds=self.value)
+
+@dataclass(frozen=True, slots=True)
+class RGBColor:
+    r: int
+    g: int
+    b: int
+
+    def __post_init__(self) -> None:
+        for component in (self.r, self.g, self.b):
+            if not 0 <= component <= 255:
+                raise ValueError("RGB components must be 0..255")
+
+    def relative_luminance(self) -> float:
+        def convert(channel: int) -> float:
+            c = channel / 255
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+        return 0.2126 * convert(self.r) + 0.7152 * convert(self.g) + 0.0722 * convert(self.b)
+
+    def contrast_ratio(self, other: "RGBColor") -> float:
+        lighter = max(self.relative_luminance(), other.relative_luminance())
+        darker = min(self.relative_luminance(), other.relative_luminance())
+        return (lighter + 0.05) / (darker + 0.05)
+```
+
+Use `typing.NewType` only for very small internal distinctions. Prefer real value objects when behavior/validation/serialization is needed.
+
+## Competitors: teams and golfers
+
+Golf means not every league has teams. Model the more general concept first.
+
+```python
+from dataclasses import dataclass
+from typing import Protocol
+
+class Competitor(Protocol):
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+
+@dataclass(frozen=True, slots=True)
+class Team:
+    id: LeagueScopedId
+    league: League
+    display_name: str
+    short_name: str
+    abbreviation: str
+    primary_color: RGBColor
+    secondary_color: RGBColor
+    logo: "LogoAsset"
+
+    def best_text_color_on_primary(self) -> RGBColor:
+        white = RGBColor(255, 255, 255)
+        black = RGBColor(0, 0, 0)
+        return white if white.contrast_ratio(self.primary_color) >= black.contrast_ratio(self.primary_color) else black
+
+@dataclass(frozen=True, slots=True)
+class BaseballTeam(Team):
+    division: str | None = None
+    league_side: str | None = None  # AL/NL, intentionally typed later if desired
+
+@dataclass(frozen=True, slots=True)
+class Golfer:
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+    country: str | None = None
+```
+
+A provider should resolve raw team/player IDs through a registry and return these objects. Renderers should not know ESPN/MLB raw IDs.
+
+## Contest model
+
+Use `Contest` instead of assuming team-vs-team `Game` everywhere.
+
+```python
+@dataclass(frozen=True, slots=True)
+class Contest:
+    id: LeagueScopedId
+    league: League
+    status: GameStatus
+    scheduled_start: datetime
+    competitors: tuple[Competitor, ...]
+    venue_name: str | None = None
+
+    @property
+    def sport(self) -> Sport:
+        return self.league.sport
+
+@dataclass(frozen=True, slots=True)
+class TeamGame(Contest):
+    away: Team
+    home: Team
+
+    def __post_init__(self) -> None:
+        if self.away == self.home:
+            raise ValueError("home and away teams must differ")
+
+@dataclass(frozen=True, slots=True)
+class GolfTournament(Contest):
+    tournament_name: str = ""
+    round_number: int | None = None
+    cut_line: int | None = None
+```
+
+## GameEvent redesign
+
+Generic event base:
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Generic, TypeVar
+
+EventTypeT = TypeVar("EventTypeT", bound=Enum)
+PayloadT = TypeVar("PayloadT")
+
+@dataclass(frozen=True, slots=True)
+class EventImportance:
+    priority: DisplayPriority
+    urgency: UpdateUrgency
+    leverage: float
+    rarity: float
+    favorite_relevance: float
+    reasons: tuple[str, ...] = ()
+
+    def combined_score(self) -> float:
+        return (
+            int(self.priority)
+            + int(self.urgency) * 5
+            + self.leverage * 20
+            + self.rarity * 15
+            + self.favorite_relevance * 20
+        )
+
+@dataclass(frozen=True, slots=True)
+class GameEvent(Generic[EventTypeT, PayloadT]):
+    id: LeagueScopedId
+    contest: Contest
+    event_type: EventTypeT
+    source: SourceRef
+    source_time: datetime
+    observed_at: datetime
+    competitors: tuple[Competitor, ...]
+    importance: EventImportance
+    payload: PayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league
+```
+
+Baseball specialization:
+
+```python
+@dataclass(frozen=True, slots=True)
+class BaseballCount:
+    balls: int
+    strikes: int
+    outs: int
+
+@dataclass(frozen=True, slots=True)
+class BaseballBaseState:
+    first: BaseballTeam | None = None  # replace with Runner once modeled
+    second: BaseballTeam | None = None
+    third: BaseballTeam | None = None
+
+@dataclass(frozen=True, slots=True)
+class BaseballPlayPayload:
+    inning: int
+    half: str  # later: HalfInning enum
+    count: BaseballCount | None
+    description: str
+    rbi: int = 0
+    pitch_type: str | None = None
+    fielder_sequence: tuple[int, ...] = ()
+
+@dataclass(frozen=True, slots=True)
+class BaseballGameEvent(GameEvent[BaseballGameEventType, BaseballPlayPayload]):
+    pass
+```
+
+Important: `fielder_sequence` is structured as `tuple[int, ...]`, not a string like `"9-6-4-"`. Rendering converts it to a string late and can avoid truncating dangling delimiters.
+
+## ScoreboardCard redesign
+
+`ScoreboardCard` should be a renderable domain object, not a loose payload bag.
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Generic, TypeVar
+
+CardPayloadT = TypeVar("CardPayloadT")
+
+@dataclass(frozen=True, slots=True)
+class CardId:
+    raw: str
+
+@dataclass(frozen=True, slots=True)
+class DedupeKey:
+    raw: str
+
+@dataclass(frozen=True, slots=True)
+class DisplayTiming:
+    available_at: datetime
+    expires_at: datetime | None
+    min_display: DurationSeconds
+    max_display: DurationSeconds
+
+    def is_available(self, now: datetime) -> bool:
+        return now >= self.available_at and (self.expires_at is None or now < self.expires_at)
+
+@dataclass(frozen=True, slots=True)
+class LayoutSupport:
+    profiles: frozenset[PanelProfile]
+    fallback_card_kind: str | None = None
+    compromise_notes: tuple[str, ...] = ()
+
+    def supports(self, profile: PanelProfile) -> bool:
+        return profile in self.profiles
+
+@dataclass(frozen=True, slots=True)
+class CardPriority:
+    band: DisplayPriority
+    score: float
+    reasons: tuple[str, ...]
+
+@dataclass(frozen=True, slots=True)
+class ScoreboardCard(Generic[CardPayloadT]):
+    id: CardId
+    kind: "CardKind"
+    contest: Contest
+    source_event_ids: tuple[LeagueScopedId, ...]
+    timing: DisplayTiming
+    priority: CardPriority
+    layout_support: LayoutSupport
+    dedupe_key: DedupeKey
+    payload: CardPayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league
+```
+
+## Card payload examples
+
+```python
+@dataclass(frozen=True, slots=True)
+class LiveBaseballCardPayload:
+    score: "ScoreState"
+    count: BaseballCount
+    base_state: BaseballBaseState
+    inning: int
+    half: str
+    batter_name: str | None
+    pitcher_name: str | None
+    last_play: str | None
+    no_hitter_badge: bool = False
+
+@dataclass(frozen=True, slots=True)
+class GolfLeaderboardCardPayload:
+    tournament: GolfTournament
+    leaders: tuple["GolfLeaderboardRow", ...]
+    favorite_rows: tuple["GolfLeaderboardRow", ...]
+    cut_line: int | None
+```
+
+## Provider boundaries
+
+Provider modules own raw API shape. The rest of the system never sees raw JSON.
+
+```python
+class Provider(Protocol):
+    source: SourceRef
+    league: League
+
+    def refresh(self) -> "ProviderUpdate": ...
+```
+
+Provider update should contain typed domain objects:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProviderUpdate:
+    source: SourceRef
+    observed_at: datetime
+    contests: tuple[Contest, ...]
+    events: tuple[GameEvent, ...]
+    warnings: tuple[str, ...] = ()
+```
+
+## Queue responsibilities
+
+- `DelayBuffer`: owns TV-delay semantics.
+- `PriorityScorer`: converts events/domain states into `CardPriority`.
+- `CardFactory`: converts events into typed card payloads.
+- `InterleavedCardQueue`: picks the next eligible card with fairness across leagues/contests.
+
+Do not put delay logic in renderers.
+Do not put provider polling logic in card classes.
+Do not let one league's provider starve the display.
+
+## Rendering contract
+
+```python
+class Renderer(Protocol[CardPayloadT]):
+    supported_profiles: frozenset[PanelProfile]
+
+    def render(
+        self,
+        card: ScoreboardCard[CardPayloadT],
+        profile: PanelProfile,
+        canvas: "Canvas",
+    ) -> None: ...
+```
+
+Renderers are pure-ish: given a card, profile, and frame time, they draw a frame. They should not fetch data.
+
+## Type-checking and code-quality policy
+
+Start with incremental strictness rather than boiling the ocean.
+
+Recommended practices:
+
+- `from __future__ import annotations` in all new files.
+- `@dataclass(frozen=True, slots=True)` for value/domain objects unless mutation is intentional.
+- `Protocol` for provider/renderer interfaces.
+- `typing.override` where Python version supports it, or `typing_extensions.override`.
+- `assert_never` for exhaustive enum matching where practical.
+- `Final` for constants.
+- No `Any` in domain code without a comment explaining the boundary.
+- No raw API JSON beyond `providers/*`.
+- No renderer dependency on ESPN/MLB/StatsAPI field names.
+- Keep serialization explicit: enums use `to_json_value()`.
+- Use pytest fixture replay and golden-image snapshot tests.
+
+Potential toolchain:
+
+- `mypy` or `pyright` for new `omni/*` modules.
+- `ruff` for linting and formatting if introduced carefully.
+- `pytest` for fixtures and snapshots.
+- Avoid Pydantic as a runtime dependency until Pi performance and packaging are checked. Pydantic is attractive for config/provider boundaries, but dataclasses plus explicit parser functions may be enough.
+
+## Migration strategy
+
+1. Add typed modules alongside upstream code.
+2. Wrap existing upstream game data into typed objects without changing rendering.
+3. Add typed cards for one MLB card.
+4. Add renderer contract for that card across all three profiles.
+5. Expand card-by-card.
+6. Only then generalize for NFL/NBA/NHL/PGA.
+
+## Anti-patterns to avoid
+
+- Giant universal `GameEventType` enum covering all sports.
+- Dict payloads that leak everywhere.
+- Event priorities as unexplained floats.
+- Hard-coded team strings in renderers.
+- Cropping 128x64 cards down to 64x32.
+- TV-delay implemented separately per sport.
+- `git pull` cron with no rollback.
+- Paid data as a default dependency.

--- a/docs/agent_context/BACKLOG.yaml
+++ b/docs/agent_context/BACKLOG.yaml
@@ -1,0 +1,270 @@
+project: omni-scoreboard
+updated: "2026-06-14"
+principles:
+  - friends_and_family_scope
+  - no_consumer_saas
+  - equal_display_profile_support
+  - typed_domain_objects_over_primitives
+  - free_low_cost_data_by_default
+  - fixture_replay_before_visual_polish
+
+display_profiles:
+  - id: single_64x32
+    physical: "1x1 64x32 panel"
+    logical_width: 64
+    logical_height: 32
+    role: "primary compact family unit"
+  - id: stack_64x64
+    physical: "2x1 vertical stack of 64x32 panels or native equivalent"
+    logical_width: 64
+    logical_height: 64
+    role: "balanced rich compact layout"
+  - id: quad_128x64
+    physical: "2x2 matrix of 64x32 panels"
+    logical_width: 128
+    logical_height: 64
+    role: "legacy/rich dashboard"
+
+milestones:
+  - id: M0
+    name: repo_reset_local_foundation
+    goal: "New omni-scoreboard repo from current upstream; legacy preserved; emulator running."
+    tasks:
+      - id: M0-001
+        title: "Rename old fork to omni-scoreboard-legacy"
+        labels: [repo, github, p0]
+        acceptance:
+          - "ajszoke/omni-scoreboard no longer points to the legacy repo"
+          - "legacy repo remains accessible as omni-scoreboard-legacy"
+          - "No old branches/tags are deleted"
+      - id: M0-002
+        title: "Create revived omni-scoreboard from upstream history"
+        labels: [repo, upstream, p0]
+        notes:
+          - "May need clone-and-push path because GitHub may not allow second personal fork of same upstream."
+        acceptance:
+          - "origin points to ajszoke/omni-scoreboard"
+          - "upstream points to MLB-LED-Scoreboard/mlb-led-scoreboard"
+          - "legacy points to ajszoke/omni-scoreboard-legacy"
+      - id: M0-003
+        title: "Install/run upstream emulator"
+        labels: [emulator, dev_env, p0]
+        acceptance:
+          - "Can launch emulated scoreboard locally"
+          - "Document exact command in README or docs/dev.md"
+
+  - id: M1
+    name: typed_domain_core
+    goal: "Typed OOP foundation for leagues, teams, contests, events, cards, display profiles."
+    tasks:
+      - id: M1-001
+        title: "Add enum mixins and base enums"
+        labels: [typing, architecture, p0]
+        acceptance:
+          - "StrEnumMixin and IntEnumMixin available under omni/core/enum.py"
+          - "League, Sport, PanelProfile, GameStatus, DisplayPriority, UpdateUrgency implemented"
+          - "Enum JSON serialization policy documented"
+      - id: M1-002
+        title: "Add typed IDs/value objects"
+        labels: [typing, architecture, p0]
+        acceptance:
+          - "LeagueScopedId, SourceRef, DurationSeconds, RGBColor, LogoAsset, PanelGeometry implemented"
+      - id: M1-003
+        title: "Add competitor/team/contest model"
+        labels: [typing, domain, p0]
+        acceptance:
+          - "Team, BaseballTeam, FootballTeam, BasketballTeam, HockeyTeam, Golfer, Contest, TeamGame, GolfTournament implemented"
+      - id: M1-004
+        title: "Add sport-specific event enums"
+        labels: [typing, events, p1]
+        acceptance:
+          - "BaseballGameEventType implemented first"
+          - "NFL/NBA/NHL/PGA placeholder enums exist or are planned"
+      - id: M1-005
+        title: "Redesign GameEvent and ScoreboardCard as typed generics"
+        labels: [typing, events, cards, p0]
+        acceptance:
+          - "GameEvent[event_type, payload] generic exists"
+          - "ScoreboardCard[payload] generic exists"
+          - "DisplayTiming, CardPriority, LayoutSupport, DedupeKey implemented"
+
+  - id: M2
+    name: display_profiles_preview_snapshots
+    goal: "All three display profiles are first-class and testable."
+    tasks:
+      - id: M2-001
+        title: "Implement DisplayProfile and PanelGeometry mapping"
+        labels: [display, panels, p0]
+      - id: M2-002
+        title: "Add renderer contract with profile support declaration"
+        labels: [rendering, typing, p0]
+      - id: M2-003
+        title: "Add fixture record/replay"
+        labels: [fixtures, dev_env, p0]
+      - id: M2-004
+        title: "Add emulator/browser preview"
+        labels: [preview, dev_env, p1]
+      - id: M2-005
+        title: "Add golden-image snapshot tests per display profile"
+        labels: [testing, rendering, p1]
+
+  - id: M3
+    name: mlb_excellence
+    goal: "MLB is polished across all three profiles."
+    tasks:
+      - id: M3-001
+        title: "Fix pregame card display halt"
+        labels: [mlb, bug, p0]
+      - id: M3-002
+        title: "Wrap sync delay into TV delay presets"
+        labels: [delay, config, mlb, p0]
+      - id: M3-003
+        title: "Fix logos/backgrounds/probability colors"
+        labels: [assets, color, mlb, p1]
+        notes: ["Pirates, Twins, White Sox, BAL probability contrast called out by user."]
+      - id: M3-004
+        title: "Reinstate color-clash alt logo background logic"
+        labels: [assets, color, rendering, p1]
+      - id: M3-005
+        title: "Map SWPR pitch type"
+        labels: [mlb, data, bug, p1]
+      - id: M3-006
+        title: "Stat line debounce and anchor stabilization"
+        labels: [rendering, mlb, p1]
+      - id: M3-007
+        title: "Fix bot-right cards spacing and fielder sequence truncation"
+        labels: [rendering, mlb, p1]
+      - id: M3-008
+        title: "Preserve last-K/play-of-inning card before inning transition"
+        labels: [mlb, queue, p2]
+      - id: M3-009
+        title: "No-hitter/perfect-game sticky priority"
+        labels: [mlb, priority, p2]
+      - id: M3-010
+        title: "Backwards K and K tracker"
+        labels: [mlb, rendering, p2]
+      - id: M3-011
+        title: "Challenge and ABS state tightening"
+        labels: [mlb, data, rendering, p2]
+      - id: M3-012
+        title: "End-of-game winner/loser logic and W/L/S tightening"
+        labels: [mlb, rendering, p2]
+      - id: M3-013
+        title: "Other-game/news ticker during idle/non-active states"
+        labels: [ticker, mlb, p2]
+      - id: M3-014
+        title: "Mid-inning linescore"
+        labels: [mlb, rendering, p3]
+      - id: M3-015
+        title: "K-zone with pitch blips"
+        labels: [mlb, rendering, p3]
+      - id: M3-016
+        title: "Pitching-change transition card"
+        labels: [mlb, animation, p3]
+      - id: M3-017
+        title: "HR stats/arcs experimental card"
+        labels: [mlb, fun, p4]
+
+  - id: M4
+    name: event_queue_delay_priority
+    goal: "Generic event/card engine for all leagues."
+    tasks:
+      - id: M4-001
+        title: "Implement DelayBuffer over source_time + tv delay"
+        labels: [queue, delay, p0]
+      - id: M4-002
+        title: "Implement PriorityScorer with reason codes"
+        labels: [queue, priority, p0]
+      - id: M4-003
+        title: "Implement InterleavedCardQueue fairness across contests/leagues"
+        labels: [queue, scheduler, p0]
+      - id: M4-004
+        title: "Add sticky alert semantics"
+        labels: [queue, priority, p1]
+      - id: M4-005
+        title: "Add priority-driven polling cadence"
+        labels: [providers, priority, p2]
+
+  - id: M5
+    name: family_device_experience
+    goal: "Local setup, safe updating, sleep/wake, physical switch."
+    tasks:
+      - id: M5-001
+        title: "First-boot Wi-Fi AP and local config portal"
+        labels: [setup, wifi, p0]
+      - id: M5-002
+        title: "Safe systemd updater with rollback"
+        labels: [updater, systemd, p0]
+      - id: M5-003
+        title: "Sleep/wake/night-dim schedule"
+        labels: [device, schedule, p1]
+      - id: M5-004
+        title: "GPIO physical switch/button support"
+        labels: [hardware, gpio, p1]
+      - id: M5-005
+        title: "1x1/2x1/2x2 case-design notes and BOM"
+        labels: [hardware, case, p2]
+
+  - id: M6
+    name: nfl_support
+    goal: "First non-MLB league."
+    tasks:
+      - id: M6-001
+        title: "ESPN NFL provider spike"
+        labels: [nfl, provider, p1]
+      - id: M6-002
+        title: "NFL domain/events/cards"
+        labels: [nfl, typing, rendering, p1]
+      - id: M6-003
+        title: "NFL red-zone/scoring/turnover priority"
+        labels: [nfl, priority, p2]
+
+  - id: M7
+    name: nba_support
+    goal: "NBA favorite-team support."
+    tasks:
+      - id: M7-001
+        title: "ESPN NBA provider spike"
+        labels: [nba, provider, p2]
+      - id: M7-002
+        title: "NBA live/final/clutch cards"
+        labels: [nba, rendering, p2]
+
+  - id: M8
+    name: nhl_support
+    goal: "NHL favorite-team support."
+    tasks:
+      - id: M8-001
+        title: "NHL provider spike"
+        labels: [nhl, provider, p2]
+      - id: M8-002
+        title: "NHL power-play/goal/final cards"
+        labels: [nhl, rendering, p2]
+
+  - id: M9
+    name: pga_support
+    goal: "PGA before NCAA."
+    tasks:
+      - id: M9-001
+        title: "ESPN PGA provider spike"
+        labels: [pga, provider, p2]
+      - id: M9-002
+        title: "Golf competitor/tournament/leaderboard model"
+        labels: [pga, typing, p2]
+      - id: M9-003
+        title: "Favorite golfer and leaderboard cards"
+        labels: [pga, rendering, p2]
+      - id: M9-004
+        title: "Cut-line/final-round priority model"
+        labels: [pga, priority, p3]
+      - id: M9-005
+        title: "Evaluate DataGolf for probability/cut-line enhancements"
+        labels: [pga, api, p3]
+
+  - id: M10
+    name: ncaa_later
+    goal: "NCAA after pro sports/PGA stability."
+    tasks:
+      - id: M10-001
+        title: "NCAAF/NCAAB provider and scope assessment"
+        labels: [ncaa, provider, p4]

--- a/docs/agent_context/CLAUDE_CODE_BOOTSTRAP_OPT.md
+++ b/docs/agent_context/CLAUDE_CODE_BOOTSTRAP_OPT.md
@@ -1,0 +1,257 @@
+## User Notes: the durable artifacts for reviving this project are temporarily stored at windows downloads. these should be moved to opt as directed below:
+
+# Claude Code Bootstrap Prompt — `/opt/omni-scoreboard`
+
+Paste this file into local Claude Code as the controlling prompt for standing up the revived project.
+
+## Mission
+
+Stand up the revived `omni-scoreboard` project locally at `/opt/omni-scoreboard` and on GitHub under `ajszoke/omni-scoreboard`, preserving the current legacy fork as `ajszoke/omni-scoreboard-legacy`.
+
+Do not use `v2` in the repo name.
+
+The revived project should be based on current `MLB-LED-Scoreboard/mlb-led-scoreboard` upstream history, with old Omni work ported selectively later.
+
+## Critical caveat: GitHub double-fork behavior
+
+Renaming `ajszoke/omni-scoreboard` to `omni-scoreboard-legacy` frees the name, but it may not allow creating a second GitHub-recognized fork of the same upstream under the same personal account. If GitHub refuses to create a second fork or `gh repo fork --fork-name omni-scoreboard` tries to rename/reuse the existing fork, do not fight it.
+
+Use one of these paths:
+
+### Path A — official GitHub fork metadata
+
+Use this only if the old fork is no longer owned by `ajszoke` as a fork of upstream, or has been deleted/detached/transferred elsewhere.
+
+### Path B — practical clone-and-push repo
+
+Create `ajszoke/omni-scoreboard` as a normal GitHub repo initialized from upstream history, with `upstream` remote configured. This preserves git history and supports future upstream pulls, but the GitHub UI will not show it as a fork. This is acceptable unless the human explicitly says GitHub fork metadata is required.
+
+## Safety rules
+
+- Do not delete any repo, branch, or tag.
+- Do not force-push `main`.
+- Do not commit secrets.
+- Stop and report if authenticated GitHub user is not `ajszoke` or does not have access.
+- Stop and report if `/opt/omni-scoreboard` already exists and is non-empty unless it is clearly the intended clone.
+- Use SSH remotes for `origin` if available; HTTPS is fine for `upstream`.
+
+## Step 1 — inspect local environment
+
+Run:
+
+```bash
+set -euo pipefail
+whoami
+hostname
+pwd
+uname -a
+git --version
+python3 --version || true
+gh --version || true
+gh auth status || true
+```
+
+If `gh` is missing or unauthenticated, ask the human to install/authenticate it before modifying GitHub.
+
+## Step 2 — inspect current GitHub repos
+
+Run:
+
+```bash
+gh repo view ajszoke/omni-scoreboard --json nameWithOwner,isFork,parent,defaultBranchRef,url || true
+gh repo view ajszoke/omni-scoreboard-legacy --json nameWithOwner,isFork,parent,defaultBranchRef,url || true
+gh repo view MLB-LED-Scoreboard/mlb-led-scoreboard --json nameWithOwner,defaultBranchRef,url,isFork || true
+```
+
+Expected initial state:
+
+- `ajszoke/omni-scoreboard` exists and is a fork of upstream.
+- `ajszoke/omni-scoreboard-legacy` probably does not exist yet.
+- Upstream default branch is likely `master`.
+
+## Step 3 — preserve/rename legacy repo
+
+If `ajszoke/omni-scoreboard` exists and `ajszoke/omni-scoreboard-legacy` does not exist, rename the old repo:
+
+```bash
+gh repo rename -R ajszoke/omni-scoreboard omni-scoreboard-legacy --yes
+```
+
+Verify:
+
+```bash
+gh repo view ajszoke/omni-scoreboard-legacy --json nameWithOwner,isFork,parent,defaultBranchRef,url
+```
+
+If `omni-scoreboard-legacy` already exists, do not overwrite it. Inspect and report.
+
+## Step 4 — create the revived repo
+
+First try Path A if it appears possible:
+
+```bash
+gh repo fork MLB-LED-Scoreboard/mlb-led-scoreboard   --fork-name omni-scoreboard   --default-branch-only   --clone=false
+```
+
+Then verify:
+
+```bash
+gh repo view ajszoke/omni-scoreboard --json nameWithOwner,isFork,parent,defaultBranchRef,url
+```
+
+If this fails because the account already has a fork, use Path B:
+
+```bash
+gh repo create ajszoke/omni-scoreboard   --public   --description "Friends-and-family omni sports LED scoreboard based on MLB-LED-Scoreboard"   --clone=false
+```
+
+## Step 5 — clone to `/opt/omni-scoreboard`
+
+Prepare `/opt` safely:
+
+```bash
+if [ -e /opt/omni-scoreboard ] && [ "$(ls -A /opt/omni-scoreboard 2>/dev/null | wc -l)" -ne 0 ]; then
+  echo "/opt/omni-scoreboard already exists and is non-empty; inspect before continuing" >&2
+  exit 1
+fi
+sudo mkdir -p /opt
+sudo chown "$USER":"$USER" /opt
+```
+
+If Path A succeeded:
+
+```bash
+git clone git@github.com:ajszoke/omni-scoreboard.git /opt/omni-scoreboard
+cd /opt/omni-scoreboard
+git remote add upstream https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git || true
+git remote add legacy https://github.com/ajszoke/omni-scoreboard-legacy.git || true
+git fetch --all --tags
+```
+
+If Path B is needed:
+
+```bash
+git clone https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git /opt/omni-scoreboard
+cd /opt/omni-scoreboard
+git remote rename origin upstream
+git remote add origin git@github.com:ajszoke/omni-scoreboard.git
+git remote add legacy https://github.com/ajszoke/omni-scoreboard-legacy.git || true
+git fetch --all --tags
+git push -u origin HEAD:main
+```
+
+If upstream default branch is `master`, decide whether local `main` should track a renamed branch or whether to keep `master`. Preferred for Omni is `main`, but preserve upstream tracking via the `upstream` remote.
+
+If current branch is `master` and we want `main`:
+
+```bash
+git branch -M main
+git push -u origin main
+```
+
+Set default branch in GitHub if needed:
+
+```bash
+gh repo edit ajszoke/omni-scoreboard --default-branch main || true
+```
+
+## Step 6 — add initial agent context
+
+Create directories:
+
+```bash
+mkdir -p docs/agent_context .cursor/rules starter_code
+```
+
+Copy the provided context artifacts into:
+
+```text
+docs/agent_context/ROADMAP.md
+docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md
+docs/agent_context/BACKLOG.yaml
+AGENTS.md
+.cursor/rules/omni-scoreboard.mdc
+starter_code/enum_core.py
+starter_code/domain_model_sketch.py
+```
+
+Commit them:
+
+```bash
+git checkout -b agent/bootstrap-context
+
+git add AGENTS.md .cursor/rules/omni-scoreboard.mdc docs/agent_context starter_code
+
+git commit -m "Add Omni Scoreboard agent context and typed architecture plan"
+git push -u origin agent/bootstrap-context
+```
+
+Create a PR if desired:
+
+```bash
+gh pr create   --repo ajszoke/omni-scoreboard   --base main   --head agent/bootstrap-context   --title "Add Omni Scoreboard roadmap and agent context"   --body "Adds roadmap, typed domain architecture, backlog, Cursor/agent rules, and bootstrap context for the revived Omni Scoreboard project."
+```
+
+If not using PRs yet, merge locally only after human approval.
+
+## Step 7 — install/run upstream emulator
+
+From `/opt/omni-scoreboard`, inspect upstream docs and do the least-invasive install first.
+
+Try:
+
+```bash
+cd /opt/omni-scoreboard
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip setuptools wheel
+```
+
+Then inspect install files before running anything with `sudo`:
+
+```bash
+ls -la
+sed -n '1,220p' install.sh || true
+sed -n '1,220p' README.md || true
+```
+
+If dependencies are clear, install for emulator/dev. Prefer venv-local installs before system installs.
+
+Try running emulator according to upstream current docs, likely one of:
+
+```bash
+./main.py --emulated
+python3 main.py --emulated
+```
+
+If missing dependencies, install only what is required and record commands in `docs/dev_setup.md`.
+
+## Step 8 — first implementation branch after bootstrap
+
+After context PR/commit exists, create the first real implementation branch:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b agent/typed-domain-foundation
+```
+
+Implement in small steps:
+
+1. Add `omni/core/enum.py` from `starter_code/enum_core.py`.
+2. Add tests for enum serialization and coercion.
+3. Add `League`, `Sport`, `PanelProfile`, `GameStatus`, `DisplayPriority`, `UpdateUrgency`.
+4. Add `LeagueScopedId`, `SourceRef`, `DurationSeconds`, `RGBColor`.
+5. Run tests/type checks.
+6. Commit.
+
+## Done criteria for this bootstrap
+
+Report back with:
+
+- GitHub repo URLs for legacy and revived repos.
+- Whether revived repo is an official GitHub fork or clone-and-push normal repo.
+- `/opt/omni-scoreboard` remotes.
+- Current branch and latest commit hash.
+- Emulator status and exact command used.
+- Any blockers, especially GitHub double-fork behavior, auth, DNS, or install failures.

--- a/docs/agent_context/README.md
+++ b/docs/agent_context/README.md
@@ -1,0 +1,30 @@
+# Omni Scoreboard Context Pack
+
+Purpose: provide durable, agent-ingestible context for reviving `omni-scoreboard` as a friends-and-family LED sports scoreboard project.
+
+Primary product scope:
+
+- Build small scoreboard boxes for friends and family.
+- Do not chase full consumer-grade competitor scope.
+- Equally support three display profiles:
+  - `single_64x32`: 1x1 64x32 panel.
+  - `stack_64x64`: 2x1 stack of two 64x32 panels, yielding 64x64.
+  - `quad_128x64`: 2x2 matrix of four 64x32 panels, yielding 128x64.
+- MLB remains the quality baseline.
+- Expansion order: MLB first, then NFL, NBA, NHL, PGA, then NCAA only after the above are stable.
+
+Files in this pack:
+
+- `ROADMAP.md` — comprehensive product and implementation roadmap.
+- `ARCHITECTURE_TYPED_DOMAIN.md` — typed/OOP architecture proposal and model sketches.
+- `BACKLOG.yaml` — issue-like structured backlog for agents.
+- `AGENTS.md` — repo-level agent orientation; drop at repository root.
+- `.cursor/rules/omni-scoreboard.mdc` — Cursor rule file; drop into `.cursor/rules/`.
+- `CLAUDE_CODE_BOOTSTRAP_OPT.md` — separate local Claude Code prompt for standing up GitHub and `/opt/omni-scoreboard`.
+- `starter_code/enum_core.py` — starter enum mixins and initial enums, cribbing the uploaded enum style.
+- `starter_code/domain_model_sketch.py` — typed domain/event/card sketch.
+- `SOURCES.md` — research basis and URLs.
+
+Important repository caveat:
+
+Renaming `ajszoke/omni-scoreboard` to `omni-scoreboard-legacy` frees the repository name, but it may not by itself permit creating a second personal GitHub fork of the same upstream. The bootstrap guide includes two paths: an official-fork path if the legacy fork is transferred/deleted/detached, and a practical clone-and-push path that preserves upstream history without GitHub fork metadata.

--- a/docs/agent_context/ROADMAP.md
+++ b/docs/agent_context/ROADMAP.md
@@ -1,0 +1,382 @@
+# Omni Scoreboard Roadmap
+
+## North star
+
+Omni Scoreboard is a tiny, opinionated sports-awareness appliance for friends and family.
+
+It should answer these questions at a glance:
+
+- Is my team playing?
+- What is the score?
+- Is anything important happening?
+- Did I miss a big play?
+- Is the game close?
+- Is there a no-hitter, red-zone drive, late comeback, cut-line sweat, or other high-leverage moment?
+- Can a non-Linux person plug it in, configure Wi-Fi, pick teams, and mostly forget it?
+
+Non-goals:
+
+- No full consumer SaaS.
+- No App Store app for initial setup.
+- No accounts unless absolutely necessary.
+- No paid data by default.
+- No fragile cron-based updater that can brick every family device at once.
+
+## Repository strategy
+
+### Facts
+
+- `ajszoke/omni-scoreboard` is currently a fork of `MLB-LED-Scoreboard/mlb-led-scoreboard`.
+- The legacy fork has 0 forks and 0 stars/watchers in the GitHub UI; renaming it has effectively no public blast radius.
+- Upstream is heavily diverged and active. The compare view shows upstream ahead by 809 commits and 177 files changed relative to the legacy fork comparison.
+- Upstream already supports board dimensions including 64x32, 64x64, and 128x64.
+- Upstream has useful modern foundation pieces: config schemas, plugin support, emulator mode, news/standings plugins, broadcast sync delay, API refresh configuration, Pi 5 work, frame pacing, and ABS indicator work.
+
+### Recommendation
+
+Use the name `omni-scoreboard` for the revived project, with no `v2` suffix.
+
+Preferred local/git shape:
+
+```text
+origin   -> git@github.com:ajszoke/omni-scoreboard.git
+upstream -> https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git
+legacy   -> https://github.com/ajszoke/omni-scoreboard-legacy.git
+```
+
+Because GitHub generally does not allow multiple forks of the same upstream under one owner, the new repo may need to be a normal repo created from an upstream clone rather than a GitHub-recognized fork. That is acceptable for this project as long as `upstream` remains configured and history is preserved.
+
+### Branching
+
+```text
+main          stable-ish human-usable branch
+agent/*       agent work branches
+feature/*     human-authored feature branches
+legacy/*      ported feature branches from old Omni commits
+upstream-sync temporary branch for upstream rebases/merge tests
+```
+
+Do not use `omni-v2` in branch or repo names unless it is a disposable local branch.
+
+## Supported displays: equal support, different compromises
+
+All meaningful features must declare behavior for each of these profiles.
+
+| Profile | Physical shape | Logical size | Product role | Design stance |
+|---|---:|---:|---|---|
+| `single_64x32` | 1x1 | 64x32 | Primary compact family unit | Sports pager: fewer, sharper cards |
+| `stack_64x64` | 2x1 vertical stack | 64x64 | New third supported layout | Rich single-game view; excellent for stat cards |
+| `quad_128x64` | 2x2 | 128x64 | Legacy/rich mode | Dense dashboard; animations and multi-region layouts |
+
+### Layout policy
+
+Every renderer must implement one of:
+
+1. Native support for all three profiles.
+2. Native support for one or two profiles plus an explicit, tested compromise for the others.
+3. A declaration that the card is not eligible for a profile, with a fallback card defined.
+
+Do not silently cram 128x64 content into 64x32.
+
+### Suggested display roles by profile
+
+| Feature | 64x32 | 64x64 | 128x64 |
+|---|---|---|---|
+| Live MLB at-bat | Score, inning, count, outs, bases | Add batter/pitcher and abbreviated play text | Full live dashboard |
+| Pregame | Matchup, start time, probable pitcher initials | Add probable pitcher names and odds/probability | Full pregame card with odds, weather, probable pitchers |
+| Probability bar | Thin, high contrast | Standard bar plus percentage | Full win-prob module with trend if available |
+| No-hitter/perfect game | Badge plus recurring full-screen alert | Sticky ribbon plus pitcher line | Dedicated panel region/sticky alert |
+| Last K / play-of-inning | Full-screen micro-card before inning card | Micro-card plus inning transition | Preserve in lower/right event queue |
+| K-zone | Maybe count-only; optional 3x3 blips | Simple zone/blips | Full pitch-location mini-map |
+| Other-game ticker | Idle states only | Idle states and lower ribbon | Persistent bottom ticker during non-active states |
+| Pitching change | Compact substitution card | Split outgoing/incoming stats | Full takeover animation |
+| HR arcs/3D | Defer/fallback text | Simple animation | Fun rich animation |
+
+## Phase plan
+
+### Phase 0 — Project reset and local foundation
+
+Goal: revive the repo cleanly without carrying old divergence as technical debt.
+
+Tasks:
+
+- Rename legacy repo to `omni-scoreboard-legacy`.
+- Create new `omni-scoreboard` from current upstream history.
+- Add remotes: `origin`, `upstream`, `legacy`.
+- Confirm upstream current release and default branch.
+- Add this context pack to `docs/agent_context/` or equivalent.
+- Establish local path `/opt/omni-scoreboard`.
+- Run upstream in emulator mode.
+- Run upstream on hardware if available.
+- Create `main` and first `agent/bootstrap-foundation` branch.
+
+Definition of done:
+
+- `git remote -v` is correct.
+- `python3 main.py --emulated` or upstream equivalent launches.
+- A README note documents the legacy remote and migration strategy.
+- A first PR exists or the first bootstrap commit is pushed.
+
+### Phase 1 — Typed domain core
+
+Goal: stop primitives from leaking through the project.
+
+Tasks:
+
+- Add `omni/core/enum.py`, cribbed from the uploaded enum mixin style.
+- Add typed `League`, `Sport`, `PanelProfile`, `GameStatus`, `CardKind`, `PriorityBand`, and `UpdateUrgency` enums.
+- Add value objects for IDs, timestamps, durations, colors, logos, display dimensions, panel profiles, and source metadata.
+- Define base `Competitor`, `Team`, `Athlete`, `Contest`, `GameEvent`, and `ScoreboardCard` classes.
+- Add sport-specific event type enums, beginning with `BaseballGameEventType`.
+- Add `BaseballTeam`, `FootballTeam`, `BasketballTeam`, `HockeyTeam`, and `Golfer`/`GolfCompetitor` domain classes.
+- Add `from __future__ import annotations`, `slots=True`, `frozen=True` value objects where practical.
+- Add mypy/pyright guardrails incrementally.
+
+Definition of done:
+
+- No new core code accepts raw league strings or team strings except at API/config boundaries.
+- Provider code converts raw API data into domain objects immediately.
+- Renderer code consumes domain/card objects rather than raw provider JSON.
+
+### Phase 2 — Display profiles and preview/snapshot tooling
+
+Goal: make all three supported layouts real and testable.
+
+Tasks:
+
+- Add `DisplayProfile` definitions:
+  - `single_64x32`
+  - `stack_64x64`
+  - `quad_128x64`
+- Map profiles to matrix flags/config.
+- Add renderer contract: each card declares supported profiles and fallback behavior.
+- Add emulator preview command.
+- Add fixture record/replay command.
+- Add PNG snapshot generation per profile.
+- Add golden-image tests for spacing-sensitive cards.
+
+Definition of done:
+
+```bash
+omni preview --profile single_64x32 --fixture fixtures/mlb/live-close-game.json
+omni preview --profile stack_64x64 --fixture fixtures/mlb/live-close-game.json
+omni preview --profile quad_128x64 --fixture fixtures/mlb/live-close-game.json
+omni snapshot test
+```
+
+### Phase 3 — MLB excellence
+
+Goal: make MLB delightful and reliable before expanding leagues.
+
+P0/P1 fixes:
+
+- Investigate and fix pregame cards halting the display permanently.
+- Implement TV-delay presets over upstream `sync_delay_seconds` semantics.
+- Fix team logo asset problems and background contrast.
+- Reinstate color-clash logic with alternate logo backgrounds.
+- Add probability-bar contrast validation.
+- Add SWPR pitch type mapping so it does not display as `UNKW`.
+- Fix stat-line debounce and horizontal bouncing.
+- Fix bot-right cards: sacs, RBI, complex plays.
+- Fix truncated fielder sequences like `9-6-4-`.
+- Fix end-of-game winner rendering: fade loser by winner, not screen position.
+- Tighten W/L/S pitcher rotation.
+- Nudge runline and extra-innings spacing.
+
+P2/P3 improvements:
+
+- Preserve last K / play-of-inning before mid/end-inning transition.
+- Add backwards K / K tracker.
+- Add no-hitter/perfect-game sticky priority.
+- Add challenge/ABS tightening.
+- Add idle-state ticker for other games/news.
+- Add mid-inning linescore, especially on 64x64 and 128x64.
+- Add K-zone with pitch blips on 64x64/128x64; fallback on 64x32.
+- Add pitching-change transition card.
+- Add HR stats/arcs as fun rich-mode polish.
+
+Definition of done:
+
+- MLB runs well across all three profiles.
+- Fixture tests cover no-hitter, perfect-game, strikeout, challenge, pitching change, complex play, extra innings, final, and pregame states.
+- 64x32 does not feel like a broken crop of 128x64.
+
+### Phase 4 — Delayed event queue and priority engine
+
+Goal: replace state-only rotation with an event/card queue.
+
+Core concepts:
+
+```text
+Provider raw data
+  -> Provider normalizer
+  -> Typed domain events
+  -> TV-delay buffer
+  -> Priority scorer
+  -> Interleaved card queue
+  -> Renderer selected by display profile
+  -> LED matrix / emulator
+```
+
+Requirements:
+
+- Events become eligible only after `source_time + selected_delay`.
+- Cards carry display timing, dedupe keys, priority reasons, and profile support.
+- Favorite-team and high-leverage events poll more often and display longer.
+- No-hitter/perfect-game, red-zone, late close game, cut-line, and final alerts can become sticky.
+- The queue interleaves sports rather than letting one provider monopolize the display.
+
+Priority signals:
+
+| Domain | High-priority signals |
+|---|---|
+| MLB | Favorite team, close late game, bases loaded, scoring play, HR, no-hitter/perfect-game, challenge/ABS, final |
+| NFL | Favorite team, red zone, scoring play, turnover, 2-minute drill, close late game, final |
+| NBA | Favorite team, clutch time, lead change, run, final minute, final |
+| NHL | Favorite team, power play, empty net, tie/one-goal late game, final |
+| PGA | Favorite golfers, majors, leader/cut-line movement, final-round back nine, playoff, cut sweat |
+
+Definition of done:
+
+- Queue behavior is deterministic under fixture replay.
+- TV delay prevents score spoilers for configured sources.
+- High-priority cards are visible without burying normal scoreboard updates.
+
+### Phase 5 — Friends-and-family setup, updater, and device behavior
+
+Goal: make a box that can be handed to someone.
+
+Setup:
+
+- First boot without Wi-Fi creates local AP: `OmniScoreboard-XXXX`.
+- Device shows setup URL/QR or simple setup text.
+- User configures Wi-Fi, favorite teams/golfers, display profile, time zone, brightness, delay preset, sleep schedule, and optional API keys.
+- Wi-Fi credentials stay local.
+- Hosted web page, if any, is docs/static helper only.
+
+Updater:
+
+- Use a `systemd` timer, not cron.
+- Fetch `origin/main` or `stable` daily and on startup.
+- Pull only fast-forward changes.
+- Validate config before restart.
+- Store previous commit for rollback.
+- Health-check service after restart.
+
+Power/schedule:
+
+- User-defined sleep/wake schedule.
+- Night dimming.
+- Optional favorite-game wake override.
+- GPIO physical switch:
+  - Short press: display on/off.
+  - Long press: setup mode.
+  - Very long press: safe shutdown.
+
+Definition of done:
+
+- A family unit can be imaged, booted, configured locally, and updated without SSH.
+
+### Phase 6 — NFL
+
+Goal: first non-MLB league.
+
+Data:
+
+- Start with ESPN site API scoreboard data.
+- Treat ESPN as unofficial/fragile; isolate behind provider interface.
+- Add optional commercial fallback later only if needed.
+
+Minimum cards:
+
+- Pregame: matchup, kickoff, records, spread/total if available.
+- Live: score, quarter, clock, possession, down/distance.
+- Priority: red zone, score, turnover, 2-minute drill, close late game.
+- Final: winner, score, key stat.
+
+Definition of done:
+
+- Favorite NFL team can be followed across all three display profiles with TV delay and priority queue integration.
+
+### Phase 7 — NBA
+
+Goal: frequent-game league with simpler event model than baseball.
+
+Cards:
+
+- Pregame matchup.
+- Live score/period/clock.
+- Lead change.
+- Close late-game sticky.
+- Final/top scorer.
+
+Definition of done:
+
+- Favorite NBA team support works and interleaves sanely with MLB/NFL.
+
+### Phase 8 — NHL
+
+Goal: add hockey with power-play and close-game urgency.
+
+Cards:
+
+- Pregame matchup.
+- Live score/period/clock/shots if available.
+- Power play.
+- Goal alert.
+- Empty net / late close game.
+- Final.
+
+Definition of done:
+
+- Favorite NHL team support works across all display profiles.
+
+### Phase 9 — PGA
+
+Goal: support tournament/leaderboard viewing before NCAA.
+
+Data:
+
+- Start with ESPN PGA scoreboard endpoint for schedule/current tournament/leaderboard.
+- Consider DataGolf API for live model probabilities and finish/cut-line probabilities if low-cost access fits.
+- Consider SportsDataIO Golf only if a paid/trial feed becomes necessary.
+
+Product concept:
+
+PGA is not team-vs-team. It should use favorite golfers, tournament importance, leaderboard volatility, cut-line movement, and final-round pressure.
+
+Minimum cards:
+
+- Current tournament summary.
+- Favorite golfer card: position, total, today, thru, next tee time if available.
+- Leaderboard top 3/5.
+- Cut-line card on Friday.
+- Final-round back-nine pressure card.
+- Playoff/final winner card.
+
+Priority:
+
+- Favorite golfer within 3 shots of lead.
+- Favorite golfer near cut line.
+- Major championship.
+- Final round, back nine.
+- Lead change.
+- Playoff.
+
+Definition of done:
+
+- User can follow selected golfers and majors without needing paid data by default.
+
+### Phase 10 — NCAA later
+
+Goal: only after pro sports plus PGA are stable.
+
+NCAA has high data complexity: many teams, rankings, bowls, tournaments, neutral sites, conferences, and inconsistent event payloads. Treat as a later expansion.
+
+## Open decisions
+
+- Do we require GitHub-recognized fork metadata, or is a normal repo cloned from upstream with an `upstream` remote enough?
+- Do we target Python 3.10+ to match upstream runtime checks or push toward a newer typed baseline once hardware images are confirmed?
+- Do we add Pydantic for config/API boundary validation or keep runtime dependencies lighter with dataclasses plus explicit parsing?
+- What exact 64x64 physical panel arrangement is preferred: two 64x32 panels stacked vertically, or native 64x64 panel? The logical profile should support both where matrix flags allow.
+- Should odds/probability be disabled by default to avoid API keys, or enabled where free endpoints suffice?

--- a/docs/agent_context/SOURCES.md
+++ b/docs/agent_context/SOURCES.md
@@ -1,0 +1,30 @@
+# Research basis
+
+This context pack was prepared on 2026-06-14.
+
+Primary repositories and references:
+
+- Current legacy repo: https://github.com/ajszoke/omni-scoreboard
+- Upstream source repo: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard
+- Upstream compare against legacy: https://github.com/ajszoke/omni-scoreboard/compare/master...MLB-LED-Scoreboard:mlb-led-scoreboard:master
+- Upstream releases: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/releases
+- Upstream plugin API docs: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/blob/master/bullpen/README.md
+- Upstream config example: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/blob/master/config.example.json
+- GitHub CLI fork docs: https://cli.github.com/manual/gh_repo_fork
+- GitHub CLI rename docs: https://cli.github.com/manual/gh_repo_rename
+- GitHub double-fork caveat: https://github.com/cli/cli/issues/6329
+- ESPN NFL scoreboard JSON endpoint: https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard
+- ESPN NBA scoreboard JSON endpoint: https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard
+- ESPN PGA scoreboard JSON endpoint: https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard
+- DataGolf API: https://datagolf.com/api-access
+- SportsDataIO Golf API: https://sportsdata.io/pga-golf-api
+- Tidbyt product reference: https://tidbyt.com/
+- Tidbyt/Pixlet tooling: https://github.com/tidbyt/pixlet
+- Gidger Raspberry Pi sports scoreboard reference: https://github.com/gidger/rpi-led-nhl-scoreboard
+- Ty Porter LED scoreboard hardware/dev-env writeup: https://blog.ty-porter.dev/development/raspberry%20pi/emulation/2021/11/11/building-raspberry-pi-led-scoreboards.html
+
+Local execution note:
+
+- Browser-based GitHub access worked.
+- Shell-level DNS inside the sandbox did not work: `getent hosts github.com` returned no host and `git ls-remote https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git` failed with `Could not resolve host: github.com`.
+- Local Claude Code should retry all git commands on the user's machine; the sandbox DNS failure should not be assumed to apply locally.

--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -1,0 +1,22 @@
+# Status — Omni Scoreboard
+
+_Living status doc. Keep it short; update whenever project state changes (branch, PR, milestone). This is the first thing an agent should read after `AGENTS.md`._
+
+## Now (2026-06-14)
+
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**. `main` = pure upstream history.
+- Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
+- **PR #1** (`agent/bootstrap-context`) open: agent context pack + project-local agent setup. Not merged.
+- Dev env verified: **uv + `.venv`** (Py 3.12); emulator runs headless (RGBMatrixEmulator browser adapter, `http://localhost:8888/`). See `docs/dev_setup.md`.
+- Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code (`screen` `omni` + `run.sh`); reachable from WSL (`ssh omni-board`, key auth verified). Connection details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
+
+## Next
+
+- **Step 8 — typed-domain foundation:** start `omni/core/enum.py`; add `League`, `Sport`, `PanelProfile`, `GameStatus`, `DisplayPriority`, `UpdateUrgency`; value types `LeagueScopedId`, `SourceRef`, `DurationSeconds`, `RGBColor`; tests for serialization/coercion. See `docs/agent_context/ROADMAP.md` and `BACKLOG.yaml`; sketches in `starter_code/`.
+
+## Done
+
+- Renamed old fork → `omni-scoreboard-legacy` (history preserved).
+- Created revived `omni-scoreboard` (Path B: normal repo, not GitHub fork metadata; `upstream` remote wired for syncing).
+- Cloned to `/opt/omni-scoreboard`, set remotes, pushed `main` (default branch).
+- Committed agent context pack; stood up project-local Claude Code (`.claude/`, thin `CLAUDE.md`, slim `.cursor` rule).

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -1,0 +1,84 @@
+# Dev setup — Omni Scoreboard (emulator)
+
+Local development runs the scoreboard against the **RGBMatrixEmulator** — no Raspberry Pi
+hardware required. Verified on WSL2 (Ubuntu, headless) with Python 3.12.3.
+
+## Dependency isolation: `uv` + project-local `.venv`
+
+We use [uv](https://docs.astral.sh/uv/) for the dev environment. It drives the existing
+`requirements.txt`, which stays the **upstream + device-facing contract** (so pulling from
+`MLB-LED-Scoreboard/mlb-led-scoreboard` upstream stays friction-free). The virtual env
+lives at `.venv/` and is git-ignored.
+
+Install `uv` (user-local, no sudo — lands in `~/.local/bin`):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Create the venv and install deps. **Run from the repo root** so the local path deps
+(`./bullpen`, `./standings`, `./news`) resolve:
+
+```bash
+uv venv .venv --python 3.12
+uv pip install -r requirements.txt
+```
+
+Optional — generate a hash-pinned lock for reproducible device flashes (does not change
+`requirements.txt`):
+
+```bash
+uv pip compile requirements.txt -o requirements.lock
+```
+
+## Running the emulator
+
+Seed a local config the first time (git-ignored):
+
+```bash
+cp config.example.json config.json
+```
+
+Run in software-emulation mode:
+
+```bash
+.venv/bin/python main.py --emulated
+# or: source .venv/bin/activate && ./main.py --emulated
+```
+
+The emulator uses the `browser` display adapter by default (see `emulator_config.json`,
+auto-created on first run, git-ignored) and serves the panel at:
+
+```
+http://localhost:8888/
+```
+
+### Display profiles
+
+Default panel is 32x32. For the Omni target profiles, pass matrix dimensions, e.g.:
+
+```bash
+.venv/bin/python main.py --emulated --led-cols 64 --led-rows 32   # single_64x32
+```
+
+(64x64 and 128x64 profiles will be wired through the typed `PanelProfile` model — see
+`docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`.)
+
+## Headless / WSL notes
+
+- The `browser` adapter needs **no X display**. Avoid the `pygame` adapter on headless
+  machines (no video device). `allow_adapter_fallback` is on by default.
+- `config.json`, `emulator_config.json`, and `.venv/` are git-ignored.
+- Benign first-run warnings: placeholder OpenWeather API key, and optional
+  `colors/*.json` / `coordinates/*.json` overrides falling back to bundled defaults.
+
+## Raspberry Pi devices
+
+For physical units, use upstream `install.sh` (it creates its own `venv/` and installs the
+`rpi-rgb-led-matrix` driver from `requirements.rpi.txt`). That device path is unchanged by
+the `uv` dev workflow above:
+
+```bash
+sudo ./install.sh            # full hardware install
+sh install.sh --no-sudo --emulator-only   # emulator-only, no hardware drivers
+```

--- a/starter_code/domain_model_sketch.py
+++ b/starter_code/domain_model_sketch.py
@@ -1,0 +1,302 @@
+"""Typed domain model sketch for Omni Scoreboard.
+
+This is intentionally a sketch, not a finished module. Use it to guide the
+first implementation pass and split into proper packages as the repo evolves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Generic, Protocol, TypeVar
+
+from starter_code.enum_core import (
+    BaseballGameEventType,
+    CardKind,
+    DisplayPriority,
+    GameStatus,
+    League,
+    PanelProfile,
+    Sport,
+    UpdateUrgency,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    name: str
+    raw_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LeagueScopedId:
+    league: League
+    source: SourceRef
+    raw: str
+
+    def __str__(self) -> str:
+        return f"{self.league}:{self.source.name}:{self.raw}"
+
+
+@dataclass(frozen=True, slots=True)
+class DurationSeconds:
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError("duration cannot be negative")
+
+    def as_timedelta(self) -> timedelta:
+        return timedelta(seconds=self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class RGBColor:
+    r: int
+    g: int
+    b: int
+
+    def __post_init__(self) -> None:
+        for component in (self.r, self.g, self.b):
+            if not 0 <= component <= 255:
+                raise ValueError("RGB components must be 0..255")
+
+    def relative_luminance(self) -> float:
+        def convert(channel: int) -> float:
+            c = channel / 255
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+        return 0.2126 * convert(self.r) + 0.7152 * convert(self.g) + 0.0722 * convert(self.b)
+
+    def contrast_ratio(self, other: "RGBColor") -> float:
+        lighter = max(self.relative_luminance(), other.relative_luminance())
+        darker = min(self.relative_luminance(), other.relative_luminance())
+        return (lighter + 0.05) / (darker + 0.05)
+
+
+@dataclass(frozen=True, slots=True)
+class LogoAsset:
+    key: str
+    path: str
+    preferred_background: RGBColor | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PanelGeometry:
+    profile: PanelProfile
+    width: int
+    height: int
+    chain_length: int
+    parallel: int
+
+
+class Competitor(Protocol):
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class Team:
+    id: LeagueScopedId
+    league: League
+    display_name: str
+    short_name: str
+    abbreviation: str
+    primary_color: RGBColor
+    secondary_color: RGBColor
+    logo: LogoAsset
+
+    def best_text_color_on_primary(self) -> RGBColor:
+        white = RGBColor(255, 255, 255)
+        black = RGBColor(0, 0, 0)
+        return white if white.contrast_ratio(self.primary_color) >= black.contrast_ratio(self.primary_color) else black
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballTeam(Team):
+    division: str | None = None
+    league_side: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FootballTeam(Team):
+    conference: str | None = None
+    division: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BasketballTeam(Team):
+    conference: str | None = None
+    division: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HockeyTeam(Team):
+    conference: str | None = None
+    division: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Golfer:
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+    country: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Contest:
+    id: LeagueScopedId
+    league: League
+    status: GameStatus
+    scheduled_start: datetime
+    competitors: tuple[Competitor, ...]
+    venue_name: str | None = None
+
+    @property
+    def sport(self) -> Sport:
+        return self.league.sport
+
+
+@dataclass(frozen=True, slots=True)
+class TeamGame(Contest):
+    away: Team | None = None
+    home: Team | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GolfTournament(Contest):
+    tournament_name: str = ""
+    round_number: int | None = None
+    cut_line: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EventImportance:
+    priority: DisplayPriority
+    urgency: UpdateUrgency
+    leverage: float
+    rarity: float
+    favorite_relevance: float
+    reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("leverage", self.leverage),
+            ("rarity", self.rarity),
+            ("favorite_relevance", self.favorite_relevance),
+        ):
+            if not 0 <= value <= 1:
+                raise ValueError(f"{name} must be normalized 0..1")
+
+    def combined_score(self) -> float:
+        return (
+            int(self.priority)
+            + int(self.urgency) * 5
+            + self.leverage * 20
+            + self.rarity * 15
+            + self.favorite_relevance * 20
+        )
+
+
+EventTypeT = TypeVar("EventTypeT", bound=Enum)
+PayloadT = TypeVar("PayloadT")
+
+
+@dataclass(frozen=True, slots=True)
+class GameEvent(Generic[EventTypeT, PayloadT]):
+    id: LeagueScopedId
+    contest: Contest
+    event_type: EventTypeT
+    source: SourceRef
+    source_time: datetime
+    observed_at: datetime
+    competitors: tuple[Competitor, ...]
+    importance: EventImportance
+    payload: PayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballCount:
+    balls: int
+    strikes: int
+    outs: int
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballPlayPayload:
+    inning: int
+    half: str
+    count: BaseballCount | None
+    description: str
+    rbi: int = 0
+    pitch_type: str | None = None
+    fielder_sequence: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballGameEvent(GameEvent[BaseballGameEventType, BaseballPlayPayload]):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class CardId:
+    raw: str
+
+
+@dataclass(frozen=True, slots=True)
+class DedupeKey:
+    raw: str
+
+
+@dataclass(frozen=True, slots=True)
+class DisplayTiming:
+    available_at: datetime
+    expires_at: datetime | None
+    min_display: DurationSeconds
+    max_display: DurationSeconds
+
+    def is_available(self, now: datetime) -> bool:
+        return now >= self.available_at and (self.expires_at is None or now < self.expires_at)
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutSupport:
+    profiles: frozenset[PanelProfile]
+    fallback_card_kind: CardKind | None = None
+    compromise_notes: tuple[str, ...] = ()
+
+    def supports(self, profile: PanelProfile) -> bool:
+        return profile in self.profiles
+
+
+@dataclass(frozen=True, slots=True)
+class CardPriority:
+    band: DisplayPriority
+    score: float
+    reasons: tuple[str, ...]
+
+
+CardPayloadT = TypeVar("CardPayloadT")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreboardCard(Generic[CardPayloadT]):
+    id: CardId
+    kind: CardKind
+    contest: Contest
+    source_event_ids: tuple[LeagueScopedId, ...]
+    timing: DisplayTiming
+    priority: CardPriority
+    layout_support: LayoutSupport
+    dedupe_key: DedupeKey
+    payload: CardPayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league

--- a/starter_code/enum_core.py
+++ b/starter_code/enum_core.py
@@ -1,0 +1,217 @@
+"""Omni typed enum mixins and initial enums.
+
+Cribbed in spirit from the user's Alpine enum.py:
+
+- StrEnumMixin: string identifier enums where the string is canonical.
+- IntEnumMixin: ordered severity/priority enums backed by IntEnum.
+- try_coerce_enum: tolerant coercion for config/fixture/replay readers.
+
+Strict construction paths should still fail fast. Use try_coerce_enum only at
+boundaries where malformed historical input should not crash inspection tools.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum
+from typing import Any, TypeVar
+
+E = TypeVar("E", bound=Enum)
+
+
+def try_coerce_enum(enum_cls: type[E], raw: Any) -> E | None:
+    """Best-effort coerce raw input into an enum member; return None on failure."""
+    if isinstance(raw, enum_cls):
+        return raw
+    if isinstance(raw, bool):
+        return None
+    try:
+        return enum_cls(raw)
+    except (ValueError, KeyError, TypeError):
+        pass
+    if isinstance(raw, str):
+        try:
+            return enum_cls[raw.upper()]
+        except KeyError:
+            return None
+    return None
+
+
+class EnumMixin:
+    """Base for Omni typed enum mixins."""
+
+    def to_json_value(self) -> str | int:
+        return self.value  # type: ignore[attr-defined]
+
+
+class StrEnumMixin(EnumMixin):
+    """Mixin for str-backed enums where str(member) returns the raw value."""
+
+    def __str__(self) -> str:
+        return self.value  # type: ignore[attr-defined]
+
+
+class IntEnumMixin(EnumMixin):
+    """Mixin for ordered IntEnum-backed severities/priorities."""
+
+    def __str__(self) -> str:
+        return self.name.lower()  # type: ignore[attr-defined]
+
+    def to_json_value(self) -> str:
+        return self.name.lower()  # type: ignore[attr-defined]
+
+
+class Sport(StrEnumMixin, str, Enum):
+    BASEBALL = "baseball"
+    FOOTBALL = "football"
+    BASKETBALL = "basketball"
+    HOCKEY = "hockey"
+    GOLF = "golf"
+
+
+class League(StrEnumMixin, str, Enum):
+    MLB = "mlb"
+    NFL = "nfl"
+    NBA = "nba"
+    NHL = "nhl"
+    PGA = "pga"
+    NCAAF = "ncaaf"
+    NCAAB = "ncaab"
+
+    @property
+    def sport(self) -> Sport:
+        return {
+            League.MLB: Sport.BASEBALL,
+            League.NFL: Sport.FOOTBALL,
+            League.NBA: Sport.BASKETBALL,
+            League.NHL: Sport.HOCKEY,
+            League.PGA: Sport.GOLF,
+            League.NCAAF: Sport.FOOTBALL,
+            League.NCAAB: Sport.BASKETBALL,
+        }[self]
+
+
+class PanelProfile(StrEnumMixin, str, Enum):
+    SINGLE_64X32 = "single_64x32"
+    STACK_64X64 = "stack_64x64"
+    QUAD_128X64 = "quad_128x64"
+
+
+class GameStatus(StrEnumMixin, str, Enum):
+    SCHEDULED = "scheduled"
+    PREGAME = "pregame"
+    LIVE = "live"
+    DELAYED = "delayed"
+    SUSPENDED = "suspended"
+    FINAL = "final"
+    POSTPONED = "postponed"
+    CANCELED = "canceled"
+    UNKNOWN = "unknown"
+
+
+class CardKind(StrEnumMixin, str, Enum):
+    LIVE_GAME = "live_game"
+    BIG_PLAY = "big_play"
+    PREGAME = "pregame"
+    FINAL = "final"
+    TICKER = "ticker"
+    ALERT = "alert"
+    LEADERBOARD = "leaderboard"
+    SETUP = "setup"
+    OFFDAY = "offday"
+
+
+class DisplayPriority(IntEnumMixin, IntEnum):
+    BACKGROUND = 0
+    NORMAL = 10
+    FAVORITE = 20
+    HIGH_LEVERAGE = 30
+    ALERT = 40
+    STICKY = 50
+
+
+class UpdateUrgency(IntEnumMixin, IntEnum):
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    LIVE_CRITICAL = 3
+
+
+class BaseballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    PITCH = "pitch"
+    BALL = "ball"
+    CALLED_STRIKE = "called_strike"
+    SWINGING_STRIKE = "swinging_strike"
+    FOUL = "foul"
+    BALL_IN_PLAY = "ball_in_play"
+    STRIKEOUT_LOOKING = "strikeout_looking"
+    STRIKEOUT_SWINGING = "strikeout_swinging"
+    WALK = "walk"
+    HIT_BY_PITCH = "hit_by_pitch"
+    SINGLE = "single"
+    DOUBLE = "double"
+    TRIPLE = "triple"
+    HOME_RUN = "home_run"
+    SAC_FLY = "sac_fly"
+    SAC_BUNT = "sac_bunt"
+    DOUBLE_PLAY = "double_play"
+    TRIPLE_PLAY = "triple_play"
+    RUN_SCORED = "run_scored"
+    RBI = "rbi"
+    PITCHING_CHANGE = "pitching_change"
+    CHALLENGE = "challenge"
+    ABS_CHALLENGE = "abs_challenge"
+    INNING_START = "inning_start"
+    HALF_INNING_END = "half_inning_end"
+    GAME_FINAL = "game_final"
+    NO_HITTER_ACTIVE = "no_hitter_active"
+    NO_HITTER_BROKEN = "no_hitter_broken"
+    PERFECT_GAME_ACTIVE = "perfect_game_active"
+    PERFECT_GAME_BROKEN = "perfect_game_broken"
+
+
+class FootballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    DRIVE_START = "drive_start"
+    RED_ZONE = "red_zone"
+    SCORE = "score"
+    TOUCHDOWN = "touchdown"
+    FIELD_GOAL = "field_goal"
+    TURNOVER = "turnover"
+    TWO_MINUTE_WARNING = "two_minute_warning"
+    GAME_FINAL = "game_final"
+
+
+class BasketballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    SCORE_CHANGE = "score_change"
+    LEAD_CHANGE = "lead_change"
+    CLUTCH_TIME = "clutch_time"
+    TIMEOUT = "timeout"
+    GAME_FINAL = "game_final"
+
+
+class HockeyGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    GOAL = "goal"
+    POWER_PLAY = "power_play"
+    PENALTY = "penalty"
+    EMPTY_NET = "empty_net"
+    OVERTIME = "overtime"
+    SHOOTOUT = "shootout"
+    GAME_FINAL = "game_final"
+
+
+class GolfEventType(StrEnumMixin, str, Enum):
+    TOURNAMENT_SCHEDULED = "tournament_scheduled"
+    ROUND_STARTED = "round_started"
+    LEADERBOARD_UPDATE = "leaderboard_update"
+    FAVORITE_MOVED = "favorite_moved"
+    CUT_LINE_UPDATE = "cut_line_update"
+    LEAD_CHANGE = "lead_change"
+    PLAYOFF = "playoff"
+    TOURNAMENT_FINAL = "tournament_final"


### PR DESCRIPTION
Adds roadmap, typed domain architecture, backlog, Cursor/agent rules, and bootstrap context for the revived Omni Scoreboard project.

## Contents
- `AGENTS.md` — repo-root agent orientation
- `.cursor/rules/omni-scoreboard.mdc` — Cursor project rule
- `docs/agent_context/` — ROADMAP, ARCHITECTURE_TYPED_DOMAIN, BACKLOG (+ pack README/SOURCES/bootstrap prompt)
- `starter_code/` — `enum_core.py`, `domain_model_sketch.py` (typed-domain starting point)

Branched off `main` (current MLB-LED-Scoreboard upstream history). No upstream files modified. Not merged — left open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)