### PR TITLE
Add typed-domain core foundation (omni/core)

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,15 +4,17 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-14)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**. `main` = pure upstream history.
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream history + merged agent context pack (PR #1).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PR #1** (`agent/bootstrap-context`) open: agent context pack + project-local agent setup. Not merged.
-- Dev env verified: **uv + `.venv`** (Py 3.12); emulator runs headless (RGBMatrixEmulator browser adapter, `http://localhost:8888/`). See `docs/dev_setup.md`.
+- **PR #1 merged** into `main` (`a6891a3`): agent context pack + project-local agent setup. Local branch `agent/bootstrap-context` retired; `origin/agent/bootstrap-context` still present (safe to delete).
+- **Step 8 (typed-domain foundation) in progress** on branch `agent/typed-domain-foundation`: `omni/core/` landed — `enum.py` (mixins + `Sport`/`League`/`PanelProfile`/`GameStatus`/`DisplayPriority`/`UpdateUrgency` + `try_coerce_enum`), `ids.py`, `time.py`, `colors.py`, with tests in `tests/test_core_*.py`. Green locally (pytest / `mypy .` / `black --check .`; 24 new core tests). Pending review/merge.
+- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (RGBMatrixEmulator browser adapter, `http://localhost:8888/`). `pytest` now pinned in `requirements.dev.txt` (was undeclared); `starter_code/` excluded from `mypy`/`black` as reference sketches. See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code (`screen` `omni` + `run.sh`); reachable from WSL (`ssh omni-board`, key auth verified). Connection details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Step 8 — typed-domain foundation:** start `omni/core/enum.py`; add `League`, `Sport`, `PanelProfile`, `GameStatus`, `DisplayPriority`, `UpdateUrgency`; value types `LeagueScopedId`, `SourceRef`, `DurationSeconds`, `RGBColor`; tests for serialization/coercion. See `docs/agent_context/ROADMAP.md` and `BACKLOG.yaml`; sketches in `starter_code/`.
+- **Land the foundation PR** (branch `agent/typed-domain-foundation`).
+- Then grow the typed domain per `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md` migration steps: sport-specific **event-type enums** (`omni/events/`), **domain value objects** (`Competitor`/`Team`/`Contest` in `omni/domain/`), then wrap one **MLB live card** through the typed `ScoreboardCard` + renderer contract across all three panel profiles. See `ROADMAP.md` and `BACKLOG.yaml`; sketches in `starter_code/`.
 
 ## Done
 
@@ -20,3 +22,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - Created revived `omni-scoreboard` (Path B: normal repo, not GitHub fork metadata; `upstream` remote wired for syncing).
 - Cloned to `/opt/omni-scoreboard`, set remotes, pushed `main` (default branch).
 - Committed agent context pack; stood up project-local Claude Code (`.claude/`, thin `CLAUDE.md`, slim `.cursor` rule).
+- **PR #1 merged** (agent context pack + project-local agent setup).

--- a/omni/__init__.py
+++ b/omni/__init__.py
@@ -1,0 +1,6 @@
+"""Omni Scoreboard typed-domain packages.
+
+Real, typed home for the domain the `starter_code/` sketches prototype. Grow this
+package incrementally alongside the upstream tree (see
+`docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`).
+"""

--- a/omni/core/__init__.py
+++ b/omni/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core typed primitives: enums, ids, durations, colors.
+
+These are the boundary-free building blocks the rest of the domain composes from.
+Import from the submodules directly (e.g. ``from omni.core.enum import League``)
+to keep re-exports explicit under mypy's ``no_implicit_reexport``.
+"""

--- a/omni/core/colors.py
+++ b/omni/core/colors.py
@@ -1,0 +1,40 @@
+"""RGB color value object with WCAG luminance/contrast helpers.
+
+Used to pick legible text colors on team-colored backgrounds across the three
+panel profiles without hand-tuning per team.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["RGBColor"]
+
+
+@dataclass(frozen=True, slots=True)
+class RGBColor:
+    """An 8-bit-per-channel RGB color (each component 0..255)."""
+
+    r: int
+    g: int
+    b: int
+
+    def __post_init__(self) -> None:
+        for component in (self.r, self.g, self.b):
+            if not 0 <= component <= 255:
+                raise ValueError("RGB components must be 0..255")
+
+    def relative_luminance(self) -> float:
+        """WCAG relative luminance, 0.0 (black) .. 1.0 (white)."""
+
+        def convert(channel: int) -> float:
+            c = channel / 255
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+        return 0.2126 * convert(self.r) + 0.7152 * convert(self.g) + 0.0722 * convert(self.b)
+
+    def contrast_ratio(self, other: RGBColor) -> float:
+        """WCAG contrast ratio between two colors, 1.0 .. 21.0 (symmetric)."""
+        lighter = max(self.relative_luminance(), other.relative_luminance())
+        darker = min(self.relative_luminance(), other.relative_luminance())
+        return (lighter + 0.05) / (darker + 0.05)

--- a/omni/core/enum.py
+++ b/omni/core/enum.py
@@ -1,0 +1,169 @@
+"""Typed enums and tolerant coercion for the Omni Scoreboard domain.
+
+Cribbed in spirit from the Alpine ``enum.py`` approach (see
+``docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md``):
+
+- :class:`StrEnumMixin` — string-valued identifier enums where the value is
+  canonical and JSON-safe; ``str(member)`` and ``to_json_value()`` return it.
+- :class:`IntEnumMixin` — ordered severities/priorities where comparison is
+  meaningful; they serialize to their lowercased member *name*, not the int.
+- :func:`try_coerce_enum` — best-effort coercion for config/fixture/replay readers.
+
+Strict construction paths (``League("mlb")``) fail fast. ``try_coerce_enum`` is the
+only tolerant path, reserved for debugging/replay/migration at boundaries where
+malformed historical input must not crash inspection tools.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum
+from typing import TYPE_CHECKING, Any, TypeVar
+
+__all__ = [
+    "EnumMixin",
+    "StrEnumMixin",
+    "IntEnumMixin",
+    "try_coerce_enum",
+    "Sport",
+    "League",
+    "PanelProfile",
+    "GameStatus",
+    "DisplayPriority",
+    "UpdateUrgency",
+]
+
+E = TypeVar("E", bound=Enum)
+
+
+def try_coerce_enum(enum_cls: type[E], raw: Any) -> E | None:
+    """Best-effort coerce ``raw`` into a member of ``enum_cls``; ``None`` on failure.
+
+    Order: pass-through if already a member, construction by value
+    (``enum_cls(raw)``), then lookup by upper-cased name (``enum_cls[raw.upper()]``)
+    which is what lets name-serialized int enums round-trip. ``bool`` is rejected up
+    front so ``True``/``False`` never silently coerce into ``0``/``1``-valued members.
+    """
+    if isinstance(raw, enum_cls):
+        return raw
+    if isinstance(raw, bool):
+        return None
+    try:
+        return enum_cls(raw)
+    except (ValueError, KeyError, TypeError):
+        pass
+    if isinstance(raw, str):
+        try:
+            return enum_cls[raw.upper()]
+        except KeyError:
+            return None
+    return None
+
+
+class EnumMixin:
+    """Common interface for Omni typed enums (mixed into ``enum.Enum`` subclasses)."""
+
+    if TYPE_CHECKING:
+        # Provided at runtime by ``enum.Enum``; declared here for the type checker
+        # only (guarded so they never become enum members) so the mixin methods can
+        # reference ``self.value`` / ``self.name`` without per-call casts.
+        name: str
+        value: Any
+
+    def to_json_value(self) -> str | int:
+        value = self.value
+        assert isinstance(value, (str, int))  # always true for Omni enums
+        return value
+
+
+class StrEnumMixin(EnumMixin):
+    """String-valued enum: ``str(member)`` / ``to_json_value()`` return the value."""
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def to_json_value(self) -> str:
+        return str(self.value)
+
+
+class IntEnumMixin(EnumMixin):
+    """Ordered ``IntEnum`` that serializes to its lowercased member name.
+
+    Note: f-string interpolation of an int-enum member formats the backing
+    *integer* (``int.__format__``), so always serialize via ``to_json_value()`` or
+    ``str()`` — never bare ``f"{member}"``.
+    """
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    def to_json_value(self) -> str:
+        return self.name.lower()
+
+
+class Sport(StrEnumMixin, str, Enum):
+    BASEBALL = "baseball"
+    FOOTBALL = "football"
+    BASKETBALL = "basketball"
+    HOCKEY = "hockey"
+    GOLF = "golf"
+
+
+class League(StrEnumMixin, str, Enum):
+    MLB = "mlb"
+    NFL = "nfl"
+    NBA = "nba"
+    NHL = "nhl"
+    PGA = "pga"
+    NCAAF = "ncaaf"
+    NCAAB = "ncaab"
+
+    @property
+    def sport(self) -> Sport:
+        return _LEAGUE_SPORT[self]
+
+
+# Defined after both enums; built once rather than per `League.sport` access. The
+# `test_every_league_maps_to_a_sport` test guards completeness when leagues are added.
+_LEAGUE_SPORT: dict[League, Sport] = {
+    League.MLB: Sport.BASEBALL,
+    League.NFL: Sport.FOOTBALL,
+    League.NBA: Sport.BASKETBALL,
+    League.NHL: Sport.HOCKEY,
+    League.PGA: Sport.GOLF,
+    League.NCAAF: Sport.FOOTBALL,
+    League.NCAAB: Sport.BASKETBALL,
+}
+
+
+class PanelProfile(StrEnumMixin, str, Enum):
+    SINGLE_64X32 = "single_64x32"
+    STACK_64X64 = "stack_64x64"
+    QUAD_128X64 = "quad_128x64"
+
+
+class GameStatus(StrEnumMixin, str, Enum):
+    SCHEDULED = "scheduled"
+    PREGAME = "pregame"
+    LIVE = "live"
+    DELAYED = "delayed"
+    SUSPENDED = "suspended"
+    FINAL = "final"
+    POSTPONED = "postponed"
+    CANCELED = "canceled"
+    UNKNOWN = "unknown"
+
+
+class DisplayPriority(IntEnumMixin, IntEnum):
+    BACKGROUND = 0
+    NORMAL = 10
+    FAVORITE = 20
+    HIGH_LEVERAGE = 30
+    ALERT = 40
+    STICKY = 50
+
+
+class UpdateUrgency(IntEnumMixin, IntEnum):
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    LIVE_CRITICAL = 3

--- a/omni/core/ids.py
+++ b/omni/core/ids.py
@@ -1,0 +1,33 @@
+"""Source and identity value objects for the Omni domain.
+
+Providers resolve raw API ids into :class:`LeagueScopedId` so the same numeric id
+from two leagues/sources never collides, and renderers never see raw provider ids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omni.core.enum import League
+
+__all__ = ["SourceRef", "LeagueScopedId"]
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    """Names a data source (e.g. ``mlb_statsapi``, ``espn``, ``datagolf``)."""
+
+    name: str
+    raw_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LeagueScopedId:
+    """A raw provider id scoped by league + source."""
+
+    league: League
+    source: SourceRef
+    raw: str
+
+    def __str__(self) -> str:
+        return f"{self.league}:{self.source.name}:{self.raw}"

--- a/omni/core/time.py
+++ b/omni/core/time.py
@@ -1,0 +1,26 @@
+"""Duration value object for the Omni domain (TV-delay, display timing).
+
+A typed alternative to the loose ``min_seconds`` / ``max_seconds`` ints the type
+policy in ``AGENTS.md`` warns against scattering across the code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+__all__ = ["DurationSeconds"]
+
+
+@dataclass(frozen=True, slots=True)
+class DurationSeconds:
+    """A non-negative whole-second duration."""
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError("duration cannot be negative")
+
+    def as_timedelta(self) -> timedelta:
+        return timedelta(seconds=self.value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.black]
 line-length = 120
+extend-exclude = "starter_code/"  # reference sketches, not production-formatted
 
 [tool.mypy]
 python_version = "3.13"
-exclude = ["venv/", "build/"]
+exclude = ["venv/", "build/", "starter_code/"]  # starter_code/ = reference sketches (grown into omni/)
 warn_return_any = true
 warn_unused_configs = true
 warn_unused_ignores = true

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,4 @@
 jsonschema-default==1.8.1
 black>=24.0
 mypy>=1.8
+pytest>=8.0

--- a/tests/test_core_enum.py
+++ b/tests/test_core_enum.py
@@ -1,0 +1,104 @@
+"""Tests for ``omni.core.enum`` — typed enums, serialization, tolerant coercion."""
+
+from __future__ import annotations
+
+import pytest
+
+from omni.core.enum import (
+    DisplayPriority,
+    GameStatus,
+    League,
+    PanelProfile,
+    Sport,
+    UpdateUrgency,
+    try_coerce_enum,
+)
+
+
+def test_str_enum_value_is_canonical() -> None:
+    assert League.MLB.value == "mlb"
+    assert str(League.MLB) == "mlb"
+    assert League.MLB.to_json_value() == "mlb"
+    assert League.MLB == "mlb"  # str-backed: equal to its raw string
+
+
+def test_str_enum_constructs_from_value() -> None:
+    assert League("mlb") is League.MLB
+    assert GameStatus("live") is GameStatus.LIVE
+
+
+def test_panel_profiles_cover_supported_displays() -> None:
+    # The three profiles AGENTS.md requires every UI feature to consider.
+    assert {p.to_json_value() for p in PanelProfile} == {
+        "single_64x32",
+        "stack_64x64",
+        "quad_128x64",
+    }
+
+
+def test_int_enum_serializes_by_name_and_orders_by_value() -> None:
+    assert int(DisplayPriority.NORMAL) == 10
+    assert str(DisplayPriority.NORMAL) == "normal"
+    assert DisplayPriority.NORMAL.to_json_value() == "normal"
+    assert DisplayPriority.ALERT > DisplayPriority.NORMAL > DisplayPriority.BACKGROUND
+
+
+def test_to_json_value_is_always_str_for_these_enums() -> None:
+    assert isinstance(League.MLB.to_json_value(), str)
+    assert isinstance(DisplayPriority.NORMAL.to_json_value(), str)
+
+
+@pytest.mark.parametrize("league", list(League))
+def test_every_league_maps_to_a_sport(league: League) -> None:
+    assert isinstance(league.sport, Sport)
+
+
+def test_league_sport_mapping_is_correct() -> None:
+    assert League.MLB.sport is Sport.BASEBALL
+    assert League.NFL.sport is Sport.FOOTBALL
+    assert League.NCAAF.sport is Sport.FOOTBALL
+    assert League.NBA.sport is Sport.BASKETBALL
+    assert League.NCAAB.sport is Sport.BASKETBALL
+    assert League.NHL.sport is Sport.HOCKEY
+    assert League.PGA.sport is Sport.GOLF
+
+
+def test_coerce_passthrough_and_by_value() -> None:
+    assert try_coerce_enum(League, League.NFL) is League.NFL
+    assert try_coerce_enum(League, "nfl") is League.NFL
+    assert try_coerce_enum(DisplayPriority, 10) is DisplayPriority.NORMAL
+
+
+def test_coerce_by_name_is_case_insensitive() -> None:
+    # value is "live"; by-name lookup tolerates upper/mixed case input.
+    assert try_coerce_enum(GameStatus, "LIVE") is GameStatus.LIVE
+    assert try_coerce_enum(GameStatus, "Final") is GameStatus.FINAL
+    # int enums serialize by name, so they must coerce back by name too.
+    assert try_coerce_enum(DisplayPriority, "normal") is DisplayPriority.NORMAL
+
+
+def test_coerce_rejects_unknown_and_bools() -> None:
+    assert try_coerce_enum(League, "xfl") is None
+    assert try_coerce_enum(GameStatus, None) is None
+    # bool must not slip through as int 1 (UpdateUrgency(1) == NORMAL).
+    assert try_coerce_enum(UpdateUrgency, True) is None
+    assert try_coerce_enum(UpdateUrgency, 1) is UpdateUrgency.NORMAL
+
+
+def test_str_enums_round_trip_through_json_value() -> None:
+    # Distinct loop names so mypy types each member to its own enum class.
+    for league in League:
+        assert try_coerce_enum(League, league.to_json_value()) is league
+    for status in GameStatus:
+        assert try_coerce_enum(GameStatus, status.to_json_value()) is status
+    for profile in PanelProfile:
+        assert try_coerce_enum(PanelProfile, profile.to_json_value()) is profile
+    for sport in Sport:
+        assert try_coerce_enum(Sport, sport.to_json_value()) is sport
+
+
+def test_int_enums_round_trip_through_json_value() -> None:
+    for priority in DisplayPriority:
+        assert try_coerce_enum(DisplayPriority, priority.to_json_value()) is priority
+    for urgency in UpdateUrgency:
+        assert try_coerce_enum(UpdateUrgency, urgency.to_json_value()) is urgency

--- a/tests/test_core_values.py
+++ b/tests/test_core_values.py
@@ -1,0 +1,61 @@
+"""Tests for ``omni.core`` value objects: ids, durations, colors."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import timedelta
+
+import pytest
+
+from omni.core.colors import RGBColor
+from omni.core.enum import League
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.core.time import DurationSeconds
+
+
+def test_source_ref_defaults_and_equality() -> None:
+    a = SourceRef("mlb_statsapi")
+    assert a.raw_url is None
+    assert a == SourceRef("mlb_statsapi")
+    assert a != SourceRef("espn")
+
+
+def test_league_scoped_id_str_and_hashable() -> None:
+    sid = LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "660271")
+    assert str(sid) == "mlb:mlb_statsapi:660271"
+    # frozen + slots => hashable, usable as dict/set keys.
+    assert sid in {sid}
+    twin = LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "660271")
+    assert {sid: 1}[twin] == 1
+
+
+def test_value_objects_are_frozen_and_slotted() -> None:
+    color = RGBColor(10, 20, 30)
+    with pytest.raises(FrozenInstanceError):
+        setattr(color, "r", 0)
+    assert not hasattr(color, "__dict__")  # slots => no per-instance __dict__
+
+
+def test_duration_seconds_validates_and_converts() -> None:
+    assert DurationSeconds(0).as_timedelta() == timedelta(0)
+    assert DurationSeconds(90).as_timedelta() == timedelta(seconds=90)
+    with pytest.raises(ValueError):
+        DurationSeconds(-1)
+
+
+def test_rgb_color_validates_range() -> None:
+    RGBColor(0, 0, 0)
+    RGBColor(255, 255, 255)
+    for bad in ((-1, 0, 0), (0, 256, 0), (0, 0, 999)):
+        with pytest.raises(ValueError):
+            RGBColor(*bad)
+
+
+def test_rgb_luminance_and_contrast_extremes() -> None:
+    white = RGBColor(255, 255, 255)
+    black = RGBColor(0, 0, 0)
+    assert white.relative_luminance() == pytest.approx(1.0)
+    assert black.relative_luminance() == pytest.approx(0.0)
+    # WCAG max contrast ratio is 21:1, and it is symmetric.
+    assert white.contrast_ratio(black) == pytest.approx(21.0)
+    assert black.contrast_ratio(white) == pytest.approx(21.0)


### PR DESCRIPTION
## Step 8 — typed-domain foundation

Boundary-free typed primitives the rest of the domain composes from. Scoped to the foundation only; sport-specific event enums, domain objects (`Team`/`Contest`), and cards follow in their own steps per the migration strategy in `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`.

### Added — `omni/core/`
- **`enum.py`** — `StrEnumMixin` / `IntEnumMixin` + `try_coerce_enum`; `Sport`, `League` (+ `.sport`), `PanelProfile`, `GameStatus`, `DisplayPriority`, `UpdateUrgency`. Int-enums serialize by lowercased name (and `try_coerce_enum` round-trips them by name); mixins are `mypy`-clean with **no `# type: ignore`** via type-check-only attribute declarations.
- **`ids.py`** — `SourceRef`, `LeagueScopedId`.
- **`time.py`** — `DurationSeconds`.
- **`colors.py`** — `RGBColor` with WCAG luminance/contrast.
- **`tests/test_core_*.py`** — 24 tests: serialization, name-vs-value coercion, round-trips, the bool-coercion guard, frozen/slotted/hashable invariants, WCAG extremes.

### Dev-setup fixes (pre-existing, surfaced while verifying)
- `requirements.dev.txt`: pin `pytest` — it was undeclared despite the whole suite + `test` skill depending on it (a clean `uv` install couldn't run tests).
- `pyproject.toml`: exclude `starter_code/` from `mypy`/`black`. Those are explicitly *"intentionally a sketch"* reference files, and the missing `__init__.py` was aborting `mypy .` (module found twice) before it reached any real code.

### Verification (the `test` skill's full trio)
- `pytest tests/` → **118 passed** (24 new)
- `mypy .` → **clean** (89 files)
- `black --check .` → **clean** (90 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
