### PR TITLE
Add typed domain objects (omni/domain: competitors and contests)

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -2,24 +2,24 @@
 
 _Living status doc. Keep it short; update whenever project state changes (branch, PR, milestone). This is the first thing an agent should read after `AGENTS.md`._
 
-## Now (2026-06-14)
+## Now (2026-06-17)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream history + merged agent context pack (PR #1).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream history + agent context pack (PR #1) + typed-domain core (PR #2).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PR #1 merged** into `main` (`a6891a3`): agent context pack + project-local agent setup. Local branch `agent/bootstrap-context` retired; `origin/agent/bootstrap-context` still present (safe to delete).
-- **Step 8 (typed-domain foundation) in progress** on branch `agent/typed-domain-foundation`: `omni/core/` landed — `enum.py` (mixins + `Sport`/`League`/`PanelProfile`/`GameStatus`/`DisplayPriority`/`UpdateUrgency` + `try_coerce_enum`), `ids.py`, `time.py`, `colors.py`, with tests in `tests/test_core_*.py`. Green locally (pytest / `mypy .` / `black --check .`; 24 new core tests). Pending review/merge.
-- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (RGBMatrixEmulator browser adapter, `http://localhost:8888/`). `pytest` now pinned in `requirements.dev.txt` (was undeclared); `starter_code/` excluded from `mypy`/`black` as reference sketches. See `docs/dev_setup.md`.
-- Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code (`screen` `omni` + `run.sh`); reachable from WSL (`ssh omni-board`, key auth verified). Connection details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
+- **PRs #1 and #2 merged and cleaned up**: agent context + `omni/core/` (enums + value types). Both feature branches deleted locally and on `origin`.
+- **Domain layer in progress** on branch `agent/domain-objects`: `omni/domain/` — `base.py` (`Competitor` protocol + `LogoAsset`), `teams.py` (`Team`/`BaseballTeam`), `athletes.py` (`Golfer`), `contest.py` (`Contest`/`TeamGame`/`GolfTournament`); tests in `tests/test_domain_*.py`. All domain records are `frozen/slots/kw_only`; `Competitor` is a read-only `@runtime_checkable` Protocol. Green locally (pytest / `mypy .` / `black --check .`). Pending review/merge.
+- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black` as reference sketches. See `docs/dev_setup.md`.
+- Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the foundation PR** (branch `agent/typed-domain-foundation`).
-- Then grow the typed domain per `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md` migration steps: sport-specific **event-type enums** (`omni/events/`), **domain value objects** (`Competitor`/`Team`/`Contest` in `omni/domain/`), then wrap one **MLB live card** through the typed `ScoreboardCard` + renderer contract across all three panel profiles. See `ROADMAP.md` and `BACKLOG.yaml`; sketches in `starter_code/`.
+- **Land the domain PR** (branch `agent/domain-objects`).
+- Then continue the migration (see `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`): sport-specific **event-type enums** + generic `GameEvent`/`EventImportance` (`omni/events/`), then a typed **`ScoreboardCard`** for one MLB live card, then the **renderer contract** across all three panel profiles. See `ROADMAP.md` and `BACKLOG.yaml`; sketches in `starter_code/`.
 
 ## Done
 
 - Renamed old fork → `omni-scoreboard-legacy` (history preserved).
-- Created revived `omni-scoreboard` (Path B: normal repo, not GitHub fork metadata; `upstream` remote wired for syncing).
-- Cloned to `/opt/omni-scoreboard`, set remotes, pushed `main` (default branch).
-- Committed agent context pack; stood up project-local Claude Code (`.claude/`, thin `CLAUDE.md`, slim `.cursor` rule).
-- **PR #1 merged** (agent context pack + project-local agent setup).
+- Created revived `omni-scoreboard` (Path B: normal repo; `upstream` remote wired for syncing).
+- Cloned to `/opt/omni-scoreboard`, set remotes, pushed `main`.
+- **PR #1 merged** — agent context pack + project-local Claude Code.
+- **PR #2 merged** — typed-domain core (`omni/core/`: enums, ids, time, colors + tests); pinned `pytest`, excluded `starter_code/` from lint/type.

--- a/omni/domain/__init__.py
+++ b/omni/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Typed domain objects: competitors (teams/athletes) and contests.
+
+Built on `omni.core`. Providers resolve raw API payloads into these objects so
+the queue, cards, and renderers never see provider JSON or raw ids.
+"""

--- a/omni/domain/athletes.py
+++ b/omni/domain/athletes.py
@@ -1,0 +1,19 @@
+"""Individual-athlete competitors (e.g. golf)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omni.core.ids import LeagueScopedId
+
+__all__ = ["Golfer"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Golfer:
+    """An individual competitor: no team, only a personal identity."""
+
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+    country: str | None = None

--- a/omni/domain/base.py
+++ b/omni/domain/base.py
@@ -1,0 +1,39 @@
+"""Shared domain abstractions: the Competitor protocol and logo assets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from omni.core.colors import RGBColor
+from omni.core.ids import LeagueScopedId
+
+__all__ = ["Competitor", "LogoAsset"]
+
+
+@runtime_checkable
+class Competitor(Protocol):
+    """A contest participant — a team or an individual athlete.
+
+    The general concept is modeled first because not every league has teams
+    (golf is individuals). Members are read-only properties so frozen dataclasses
+    (`Team`, `Golfer`) structurally satisfy the protocol.
+    """
+
+    @property
+    def id(self) -> LeagueScopedId: ...
+
+    @property
+    def display_name(self) -> str: ...
+
+    @property
+    def short_name(self) -> str: ...
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class LogoAsset:
+    """A logo image reference resolved by a provider/registry, not a renderer."""
+
+    key: str
+    path: str
+    preferred_background: RGBColor | None = None

--- a/omni/domain/contest.py
+++ b/omni/domain/contest.py
@@ -1,0 +1,57 @@
+"""Contests: the general team-or-individual competition model.
+
+`Contest` is the base so the system never assumes team-vs-team. `TeamGame` and
+`GolfTournament` specialize it; more sports follow the same pattern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from omni.core.enum import GameStatus, League, Sport
+from omni.core.ids import LeagueScopedId
+from omni.domain.base import Competitor
+from omni.domain.teams import Team
+
+__all__ = ["Contest", "TeamGame", "GolfTournament"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Contest:
+    """Any scheduled competition, team-based or individual."""
+
+    id: LeagueScopedId
+    league: League
+    status: GameStatus
+    scheduled_start: datetime
+    competitors: tuple[Competitor, ...] = ()
+    venue_name: str | None = None
+
+    @property
+    def sport(self) -> Sport:
+        return self.league.sport
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TeamGame(Contest):
+    """A team-vs-team contest."""
+
+    away: Team
+    home: Team
+
+    def __post_init__(self) -> None:
+        if self.away == self.home:
+            raise ValueError("home and away teams must differ")
+        if not self.competitors:
+            # Keep the general `competitors` view consistent with home/away.
+            object.__setattr__(self, "competitors", (self.away, self.home))
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GolfTournament(Contest):
+    """An individual-field contest; competitors are the golfers in the field."""
+
+    tournament_name: str
+    round_number: int | None = None
+    cut_line: int | None = None

--- a/omni/domain/teams.py
+++ b/omni/domain/teams.py
@@ -1,0 +1,42 @@
+"""Team competitors for team-sport leagues."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omni.core.colors import RGBColor
+from omni.core.enum import League
+from omni.core.ids import LeagueScopedId
+from omni.domain.base import LogoAsset
+
+__all__ = ["Team", "BaseballTeam"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Team:
+    """A team competitor carrying the colors/logo needed to render it."""
+
+    id: LeagueScopedId
+    league: League
+    display_name: str
+    short_name: str
+    abbreviation: str
+    primary_color: RGBColor
+    secondary_color: RGBColor
+    logo: LogoAsset
+
+    def best_text_color_on_primary(self) -> RGBColor:
+        """White or black text, whichever contrasts better on the primary color."""
+        white = RGBColor(255, 255, 255)
+        black = RGBColor(0, 0, 0)
+        if white.contrast_ratio(self.primary_color) >= black.contrast_ratio(self.primary_color):
+            return white
+        return black
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballTeam(Team):
+    """MLB specialization; division/league_side stay loose until modeled."""
+
+    division: str | None = None
+    league_side: str | None = None  # AL/NL

--- a/tests/test_domain_contest.py
+++ b/tests/test_domain_contest.py
@@ -1,0 +1,106 @@
+"""Tests for omni.domain contests: Contest, TeamGame, GolfTournament."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from omni.core.colors import RGBColor
+from omni.core.enum import GameStatus, League, Sport
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.athletes import Golfer
+from omni.domain.base import Competitor, LogoAsset
+from omni.domain.contest import Contest, GolfTournament, TeamGame
+from omni.domain.teams import Team
+
+KICKOFF = datetime(2026, 6, 17, 19, 5, tzinfo=timezone.utc)
+
+
+def make_team(team_id: str, name: str, abbr: str) -> Team:
+    return Team(
+        id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), team_id),
+        league=League.MLB,
+        display_name=name,
+        short_name=name.split()[-1],
+        abbreviation=abbr,
+        primary_color=RGBColor(51, 0, 111),
+        secondary_color=RGBColor(196, 206, 212),
+        logo=LogoAsset(key=abbr.lower(), path=f"assets/{abbr.lower()}.png"),
+    )
+
+
+def make_golfer(golfer_id: str, name: str) -> Golfer:
+    return Golfer(
+        id=LeagueScopedId(League.PGA, SourceRef("espn"), golfer_id),
+        display_name=name,
+        short_name=name.split()[-1],
+    )
+
+
+def make_team_game(*, status: GameStatus = GameStatus.LIVE) -> TeamGame:
+    return TeamGame(
+        id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "g1"),
+        league=League.MLB,
+        status=status,
+        scheduled_start=KICKOFF,
+        away=make_team("115", "Colorado Rockies", "COL"),
+        home=make_team("119", "Los Angeles Dodgers", "LAD"),
+    )
+
+
+def test_contest_sport_derives_from_league() -> None:
+    assert make_team_game().sport is Sport.BASEBALL
+
+
+def test_team_game_auto_derives_competitors_from_home_away() -> None:
+    game = make_team_game()
+    assert game.competitors == (game.away, game.home)
+    assert isinstance(game, Contest)
+    assert all(isinstance(c, Competitor) for c in game.competitors)
+
+
+def test_team_game_requires_distinct_teams() -> None:
+    rockies = make_team("115", "Colorado Rockies", "COL")
+    with pytest.raises(ValueError):
+        TeamGame(
+            id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "g1"),
+            league=League.MLB,
+            status=GameStatus.SCHEDULED,
+            scheduled_start=KICKOFF,
+            away=rockies,
+            home=rockies,
+        )
+
+
+def test_team_game_preserves_explicit_competitors() -> None:
+    # A provider may supply `competitors` itself; don't overwrite it.
+    away = make_team("115", "Colorado Rockies", "COL")
+    home = make_team("119", "Los Angeles Dodgers", "LAD")
+    game = TeamGame(
+        id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "g1"),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=KICKOFF,
+        competitors=(home, away),  # deliberately reversed
+        away=away,
+        home=home,
+    )
+    assert game.competitors == (home, away)
+
+
+def test_golf_tournament_holds_individual_competitors() -> None:
+    golfers = (make_golfer("1", "Scottie Scheffler"), make_golfer("2", "Rory McIlroy"))
+    tourney = GolfTournament(
+        id=LeagueScopedId(League.PGA, SourceRef("espn"), "t1"),
+        league=League.PGA,
+        status=GameStatus.LIVE,
+        scheduled_start=KICKOFF,
+        competitors=golfers,
+        tournament_name="U.S. Open",
+        cut_line=2,
+    )
+    assert tourney.sport is Sport.GOLF
+    assert tourney.tournament_name == "U.S. Open"
+    assert tourney.cut_line == 2
+    assert all(isinstance(c, Competitor) for c in tourney.competitors)

--- a/tests/test_domain_teams.py
+++ b/tests/test_domain_teams.py
@@ -1,0 +1,65 @@
+"""Tests for omni.domain teams and the Competitor protocol."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from omni.core.colors import RGBColor
+from omni.core.enum import League
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.base import Competitor, LogoAsset
+from omni.domain.teams import BaseballTeam, Team
+
+
+def make_team(*, primary_color: RGBColor = RGBColor(51, 0, 111)) -> Team:
+    return Team(
+        id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "115"),
+        league=League.MLB,
+        display_name="Colorado Rockies",
+        short_name="Rockies",
+        abbreviation="COL",
+        primary_color=primary_color,
+        secondary_color=RGBColor(196, 206, 212),
+        logo=LogoAsset(key="col", path="assets/col.png"),
+    )
+
+
+def test_team_satisfies_competitor_protocol() -> None:
+    assert isinstance(make_team(), Competitor)
+
+
+def test_best_text_color_white_on_dark_primary() -> None:
+    team = make_team(primary_color=RGBColor(0, 0, 90))  # dark navy
+    assert team.best_text_color_on_primary() == RGBColor(255, 255, 255)
+
+
+def test_best_text_color_black_on_light_primary() -> None:
+    team = make_team(primary_color=RGBColor(255, 215, 0))  # gold
+    assert team.best_text_color_on_primary() == RGBColor(0, 0, 0)
+
+
+def test_team_is_frozen_and_slotted() -> None:
+    team = make_team()
+    with pytest.raises(FrozenInstanceError):
+        setattr(team, "abbreviation", "XXX")
+    assert not hasattr(team, "__dict__")
+
+
+def test_baseball_team_is_a_team_and_competitor() -> None:
+    team = BaseballTeam(
+        id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "115"),
+        league=League.MLB,
+        display_name="Colorado Rockies",
+        short_name="Rockies",
+        abbreviation="COL",
+        primary_color=RGBColor(51, 0, 111),
+        secondary_color=RGBColor(196, 206, 212),
+        logo=LogoAsset(key="col", path="assets/col.png"),
+        division="NL West",
+    )
+    assert isinstance(team, Team)
+    assert isinstance(team, Competitor)
+    assert team.division == "NL West"
+    assert team.league_side is None


### PR DESCRIPTION
## Domain objects — `omni/domain/`

The `Competitor` / `Team` / `Contest` layer that `omni/events` and `omni/cards` will build on. Models the general concept first — not every league has teams (golf is individuals) — per `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`.

### Added
- **`base.py`** — `Competitor` (read-only `@runtime_checkable` Protocol) + `LogoAsset`.
- **`teams.py`** — `Team` (with `best_text_color_on_primary()` via the `omni.core.colors` WCAG contrast helpers), `BaseballTeam`.
- **`athletes.py`** — `Golfer`.
- **`contest.py`** — `Contest` (`.sport` derived from `league`), `TeamGame` (enforces home ≠ away; auto-derives `competitors` from home/away), `GolfTournament`.
- **`tests/test_domain_*.py`** — 10 tests: protocol satisfaction, contrast picks (white on navy / black on gold), frozen/slotted, the home≠away guard, competitor auto-derivation, individual-competitor golf field.

### Design notes
- All domain records are `frozen / slots / kw_only`. Keyword-only construction prevents positional mix-ups on wide records (e.g. `Team`'s two colors) and lets `TeamGame.away`/`home` stay **required** `Team` even though `Contest` has defaulted fields.
- `Competitor` uses read-only **properties** (not bare attributes) so the frozen dataclasses satisfy it under mypy — bare attributes would demand settable implementers.

### Verification
- `pytest tests/` → **128 passed** (10 new)
- `mypy .` → **clean** (96 files)
- `black --check .` → **clean** (97 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
