### PR TITLE
Add typed event layer (omni/events: GameEvent + sport taxonomies)

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,17 +4,17 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-17)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream history + agent context pack (PR #1) + typed-domain core (PR #2).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream history + agent context (PR #1) + typed core (PR #2) + domain objects (PR #3).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1 and #2 merged and cleaned up**: agent context + `omni/core/` (enums + value types). Both feature branches deleted locally and on `origin`.
-- **Domain layer in progress** on branch `agent/domain-objects`: `omni/domain/` — `base.py` (`Competitor` protocol + `LogoAsset`), `teams.py` (`Team`/`BaseballTeam`), `athletes.py` (`Golfer`), `contest.py` (`Contest`/`TeamGame`/`GolfTournament`); tests in `tests/test_domain_*.py`. All domain records are `frozen/slots/kw_only`; `Competitor` is a read-only `@runtime_checkable` Protocol. Green locally (pytest / `mypy .` / `black --check .`). Pending review/merge.
+- **PRs #1–#3 merged and cleaned up** (context, `omni/core/`, `omni/domain/`). Feature branches deleted locally and on `origin`.
+- **Events layer in progress** on branch `agent/events-layer`: `omni/events/` — `base.py` (generic `GameEvent[EventType, Payload]` + `EventImportance`), `baseball.py` (full vertical: event-type enum + `BaseballCount`/`BaseballPlayPayload`/`BaseballGameEvent`), and per-sport event-type enums for football/basketball/hockey/golf (taxonomy only). Tests in `tests/test_events.py` + `tests/test_event_enums.py`. Green locally. Pending review/merge.
 - Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black` as reference sketches. See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the domain PR** (branch `agent/domain-objects`).
-- Then continue the migration (see `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`): sport-specific **event-type enums** + generic `GameEvent`/`EventImportance` (`omni/events/`), then a typed **`ScoreboardCard`** for one MLB live card, then the **renderer contract** across all three panel profiles. See `ROADMAP.md` and `BACKLOG.yaml`; sketches in `starter_code/`.
+- **Land the events PR** (branch `agent/events-layer`).
+- Then the **first typed card + renderer** (migration steps 3–4 in `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`): a typed `ScoreboardCard` for one MLB live game (`omni/cards/`), then the `Renderer` contract drawing it across all three profiles (`single_64x32` / `stack_64x64` / `quad_128x64`) with a fixture/golden-image snapshot test. This is where the three-profile policy and the layout contract get exercised for real. See `ROADMAP.md` and `BACKLOG.yaml`.
 
 ## Done
 
@@ -23,3 +23,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - Cloned to `/opt/omni-scoreboard`, set remotes, pushed `main`.
 - **PR #1 merged** — agent context pack + project-local Claude Code.
 - **PR #2 merged** — typed-domain core (`omni/core/`: enums, ids, time, colors + tests); pinned `pytest`, excluded `starter_code/` from lint/type.
+- **PR #3 merged** — typed domain objects (`omni/domain/`: `Competitor`/`Team`/`Contest` + tests).

--- a/omni/events/__init__.py
+++ b/omni/events/__init__.py
@@ -1,0 +1,6 @@
+"""Typed game events: a generic `GameEvent[EventType, Payload]` base plus
+sport-specific event-type enums and payloads.
+
+Event-type enums are intentionally per-sport (no giant universal enum): a
+baseball "score" and a football "score" carry different downstream concerns.
+"""

--- a/omni/events/base.py
+++ b/omni/events/base.py
@@ -1,0 +1,77 @@
+"""Generic event model: importance scoring and the typed GameEvent base."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Generic, TypeVar
+
+from omni.core.enum import DisplayPriority, League, UpdateUrgency
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.base import Competitor
+from omni.domain.contest import Contest
+
+__all__ = ["EventTypeT", "PayloadT", "EventImportance", "GameEvent"]
+
+EventTypeT = TypeVar("EventTypeT", bound=Enum)
+PayloadT = TypeVar("PayloadT")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class EventImportance:
+    """Why an event matters, as explainable components rather than a bare float.
+
+    `leverage`, `rarity`, and `favorite_relevance` are normalized 0..1 so the
+    priority scorer can weight them consistently; `reasons` carries human-readable
+    codes for debugging why a card was promoted.
+    """
+
+    priority: DisplayPriority
+    urgency: UpdateUrgency
+    leverage: float
+    rarity: float
+    favorite_relevance: float
+    reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("leverage", self.leverage),
+            ("rarity", self.rarity),
+            ("favorite_relevance", self.favorite_relevance),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be normalized to 0..1")
+
+    def combined_score(self) -> float:
+        return (
+            int(self.priority)
+            + int(self.urgency) * 5
+            + self.leverage * 20
+            + self.rarity * 15
+            + self.favorite_relevance * 20
+        )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GameEvent(Generic[EventTypeT, PayloadT]):
+    """A typed, sport-parameterized event observed within a contest.
+
+    `event_type` and `payload` are parameterized per sport (e.g.
+    `GameEvent[BaseballGameEventType, BaseballPlayPayload]`), so a renderer or
+    scorer for one sport can never be handed another sport's event shape.
+    """
+
+    id: LeagueScopedId
+    contest: Contest
+    event_type: EventTypeT
+    source: SourceRef
+    source_time: datetime
+    observed_at: datetime
+    importance: EventImportance
+    payload: PayloadT
+    competitors: tuple[Competitor, ...] = ()
+
+    @property
+    def league(self) -> League:
+        return self.contest.league

--- a/omni/events/baseball.py
+++ b/omni/events/baseball.py
@@ -1,0 +1,86 @@
+"""Baseball event taxonomy, play payload, and typed event."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from omni.core.enum import StrEnumMixin
+from omni.events.base import GameEvent
+
+__all__ = [
+    "BaseballGameEventType",
+    "BaseballCount",
+    "BaseballPlayPayload",
+    "BaseballGameEvent",
+]
+
+
+class BaseballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    PITCH = "pitch"
+    BALL = "ball"
+    CALLED_STRIKE = "called_strike"
+    SWINGING_STRIKE = "swinging_strike"
+    FOUL = "foul"
+    BALL_IN_PLAY = "ball_in_play"
+    STRIKEOUT_LOOKING = "strikeout_looking"
+    STRIKEOUT_SWINGING = "strikeout_swinging"
+    WALK = "walk"
+    HIT_BY_PITCH = "hit_by_pitch"
+    SINGLE = "single"
+    DOUBLE = "double"
+    TRIPLE = "triple"
+    HOME_RUN = "home_run"
+    SAC_FLY = "sac_fly"
+    SAC_BUNT = "sac_bunt"
+    DOUBLE_PLAY = "double_play"
+    TRIPLE_PLAY = "triple_play"
+    RUN_SCORED = "run_scored"
+    RBI = "rbi"
+    PITCHING_CHANGE = "pitching_change"
+    CHALLENGE = "challenge"
+    ABS_CHALLENGE = "abs_challenge"
+    INNING_START = "inning_start"
+    HALF_INNING_END = "half_inning_end"
+    GAME_FINAL = "game_final"
+    NO_HITTER_ACTIVE = "no_hitter_active"
+    NO_HITTER_BROKEN = "no_hitter_broken"
+    PERFECT_GAME_ACTIVE = "perfect_game_active"
+    PERFECT_GAME_BROKEN = "perfect_game_broken"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballCount:
+    """Balls/strikes/outs at the moment of a play."""
+
+    balls: int
+    strikes: int
+    outs: int
+
+    def __post_init__(self) -> None:
+        if self.balls < 0 or self.strikes < 0 or self.outs < 0:
+            raise ValueError("balls, strikes, and outs must be non-negative")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballPlayPayload:
+    """The baseball-specific body of a `BaseballGameEvent`.
+
+    `fielder_sequence` is structured as ints (e.g. ``(9, 6, 4)``), not a string
+    like ``"9-6-4-"``; rendering joins it late and avoids dangling delimiters.
+    """
+
+    inning: int
+    half: str  # later: HalfInning enum
+    description: str
+    count: BaseballCount | None = None
+    rbi: int = 0
+    pitch_type: str | None = None
+    fielder_sequence: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballGameEvent(GameEvent[BaseballGameEventType, BaseballPlayPayload]):
+    """A `GameEvent` specialized to baseball event types and play payloads."""

--- a/omni/events/basketball.py
+++ b/omni/events/basketball.py
@@ -1,0 +1,19 @@
+"""Basketball event taxonomy. Payloads/typed event follow with the NBA provider."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from omni.core.enum import StrEnumMixin
+
+__all__ = ["BasketballGameEventType"]
+
+
+class BasketballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    SCORE_CHANGE = "score_change"
+    LEAD_CHANGE = "lead_change"
+    CLUTCH_TIME = "clutch_time"
+    TIMEOUT = "timeout"
+    GAME_FINAL = "game_final"

--- a/omni/events/football.py
+++ b/omni/events/football.py
@@ -1,0 +1,22 @@
+"""Football event taxonomy. Payloads/typed event follow with the NFL provider."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from omni.core.enum import StrEnumMixin
+
+__all__ = ["FootballGameEventType"]
+
+
+class FootballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    DRIVE_START = "drive_start"
+    RED_ZONE = "red_zone"
+    SCORE = "score"
+    TOUCHDOWN = "touchdown"
+    FIELD_GOAL = "field_goal"
+    TURNOVER = "turnover"
+    TWO_MINUTE_WARNING = "two_minute_warning"
+    GAME_FINAL = "game_final"

--- a/omni/events/golf.py
+++ b/omni/events/golf.py
@@ -1,0 +1,20 @@
+"""Golf event taxonomy. Payloads/typed event follow with the PGA provider."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from omni.core.enum import StrEnumMixin
+
+__all__ = ["GolfEventType"]
+
+
+class GolfEventType(StrEnumMixin, str, Enum):
+    TOURNAMENT_SCHEDULED = "tournament_scheduled"
+    ROUND_STARTED = "round_started"
+    LEADERBOARD_UPDATE = "leaderboard_update"
+    FAVORITE_MOVED = "favorite_moved"
+    CUT_LINE_UPDATE = "cut_line_update"
+    LEAD_CHANGE = "lead_change"
+    PLAYOFF = "playoff"
+    TOURNAMENT_FINAL = "tournament_final"

--- a/omni/events/hockey.py
+++ b/omni/events/hockey.py
@@ -1,0 +1,21 @@
+"""Hockey event taxonomy. Payloads/typed event follow with the NHL provider."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from omni.core.enum import StrEnumMixin
+
+__all__ = ["HockeyGameEventType"]
+
+
+class HockeyGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    GOAL = "goal"
+    POWER_PLAY = "power_play"
+    PENALTY = "penalty"
+    EMPTY_NET = "empty_net"
+    OVERTIME = "overtime"
+    SHOOTOUT = "shootout"
+    GAME_FINAL = "game_final"

--- a/tests/test_event_enums.py
+++ b/tests/test_event_enums.py
@@ -1,0 +1,39 @@
+"""The event-type enum taxonomy is sport-specific and JSON round-trips."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import pytest
+
+from omni.core.enum import StrEnumMixin, try_coerce_enum
+from omni.events.baseball import BaseballGameEventType
+from omni.events.basketball import BasketballGameEventType
+from omni.events.football import FootballGameEventType
+from omni.events.golf import GolfEventType
+from omni.events.hockey import HockeyGameEventType
+
+SPORT_EVENT_ENUMS = [
+    BaseballGameEventType,
+    FootballGameEventType,
+    BasketballGameEventType,
+    HockeyGameEventType,
+    GolfEventType,
+]
+
+
+@pytest.mark.parametrize("enum_cls", SPORT_EVENT_ENUMS)
+def test_event_enum_is_str_serializable_and_round_trips(enum_cls: type[Enum]) -> None:
+    members = list(enum_cls)
+    assert members  # non-empty taxonomy
+    for member in members:
+        assert isinstance(member, StrEnumMixin)
+        assert try_coerce_enum(enum_cls, member.to_json_value()) is member
+
+
+def test_event_taxonomies_are_sport_specific() -> None:
+    # No giant universal enum: a baseball type is not a football type, even when
+    # the underlying string value coincides.
+    assert BaseballGameEventType.HOME_RUN not in set(FootballGameEventType)
+    assert BaseballGameEventType.GAME_FINAL is not FootballGameEventType.GAME_FINAL
+    assert BaseballGameEventType.GAME_FINAL.value == FootballGameEventType.GAME_FINAL.value == "game_final"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,96 @@
+"""Tests for the generic event model and the baseball event vertical."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from omni.core.enum import DisplayPriority, GameStatus, League, UpdateUrgency
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.contest import Contest
+from omni.events.base import EventImportance, GameEvent
+from omni.events.baseball import (
+    BaseballCount,
+    BaseballGameEvent,
+    BaseballGameEventType,
+    BaseballPlayPayload,
+)
+
+T = datetime(2026, 6, 17, 19, 5, tzinfo=timezone.utc)
+SOURCE = SourceRef("mlb_statsapi")
+CONTEST = Contest(
+    id=LeagueScopedId(League.MLB, SOURCE, "g1"),
+    league=League.MLB,
+    status=GameStatus.LIVE,
+    scheduled_start=T,
+)
+
+
+def make_importance(
+    *,
+    priority: DisplayPriority = DisplayPriority.HIGH_LEVERAGE,
+    urgency: UpdateUrgency = UpdateUrgency.HIGH,
+    leverage: float = 0.8,
+    rarity: float = 0.5,
+    favorite_relevance: float = 0.3,
+) -> EventImportance:
+    return EventImportance(
+        priority=priority,
+        urgency=urgency,
+        leverage=leverage,
+        rarity=rarity,
+        favorite_relevance=favorite_relevance,
+    )
+
+
+def test_importance_combined_score_weights_components() -> None:
+    # 30 + 2*5 + 0.8*20 + 0.5*15 + 0.3*20 = 69.5
+    assert make_importance().combined_score() == pytest.approx(69.5)
+
+
+def test_importance_rejects_unnormalized_components() -> None:
+    with pytest.raises(ValueError):
+        make_importance(leverage=1.5)
+    with pytest.raises(ValueError):
+        make_importance(rarity=-0.1)
+    with pytest.raises(ValueError):
+        make_importance(favorite_relevance=2.0)
+
+
+def test_baseball_count_rejects_negative() -> None:
+    assert BaseballCount(balls=3, strikes=2, outs=1).strikes == 2
+    with pytest.raises(ValueError):
+        BaseballCount(balls=-1, strikes=0, outs=0)
+
+
+def test_play_payload_keeps_fielder_sequence_structured() -> None:
+    payload = BaseballPlayPayload(
+        inning=7,
+        half="bottom",
+        description="6-4-3 double play",
+        count=BaseballCount(balls=1, strikes=2, outs=1),
+        fielder_sequence=(6, 4, 3),
+    )
+    assert payload.fielder_sequence == (6, 4, 3)
+    assert isinstance(payload.fielder_sequence, tuple)
+    assert payload.rbi == 0  # default
+
+
+def test_baseball_game_event_is_typed_and_derives_league() -> None:
+    event = BaseballGameEvent(
+        id=LeagueScopedId(League.MLB, SOURCE, "e1"),
+        contest=CONTEST,
+        event_type=BaseballGameEventType.HOME_RUN,
+        source=SOURCE,
+        source_time=T,
+        observed_at=T,
+        importance=make_importance(),
+        payload=BaseballPlayPayload(inning=9, half="top", description="walk-off homer", rbi=1),
+    )
+    assert isinstance(event, GameEvent)
+    assert event.league is League.MLB
+    assert event.event_type is BaseballGameEventType.HOME_RUN
+    assert event.payload.rbi == 1
+    assert event.competitors == ()  # default
+    assert event.importance.combined_score() > 0


### PR DESCRIPTION
## Events — `omni/events/`

The typed event layer: a generic `GameEvent[EventType, Payload]` plus the baseball vertical and the sport-specific event-type enum taxonomy. This is the last domain piece before the first typed `ScoreboardCard`, per `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`.

### Added
- **`base.py`** — `EventImportance` (explainable components — priority / urgency / leverage / rarity / favorite-relevance + reasons — with a weighted `combined_score()`; the normalized fields are validated to 0..1) and the generic `GameEvent[EventTypeT, PayloadT]` (`frozen/slots/kw_only`, `.league` derived from its `Contest`).
- **`baseball.py`** — full vertical: `BaseballGameEventType` (33 members), `BaseballCount` (non-negative), `BaseballPlayPayload` (`fielder_sequence` stays `tuple[int, ...]`, not `"9-6-4-"`), and `BaseballGameEvent = GameEvent[BaseballGameEventType, BaseballPlayPayload]`.
- **`football.py` / `basketball.py` / `hockey.py` / `golf.py`** — sport-specific event-type enums (taxonomy only; payloads + typed events arrive with each sport's provider).
- **`tests/test_events.py` + `tests/test_event_enums.py`** — 11 tests: score weighting, 0..1 validation, count guard, structured fielder sequence, typed baseball event + `.league`, and that the taxonomies are genuinely per-sport (no universal enum) and JSON round-trip.

### Notes
- Event-type enums are deliberately **per-sport** — the doc's called-out anti-pattern is a giant universal `GameEventType`. A test pins that `BaseballGameEventType.GAME_FINAL` and `FootballGameEventType.GAME_FINAL` are distinct types despite sharing the `"game_final"` value.
- `GameEvent` is `Generic` + `slots` + `frozen` + `kw_only`; the baseball specialization binds the type params so a baseball scorer/renderer can never be handed another sport's event shape.

### Verification
- `pytest tests/` → **139 passed** (11 new)
- `mypy .` → **clean** (105 files)
- `black --check .` → **clean** (106 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
