### PR TITLE
QC hardening: HalfInning enum, validation, +18 gap tests, branch coverage

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -13,6 +13,10 @@ Run from the repo root with the project-local `.venv` (see `docs/dev_setup.md`):
 .venv/bin/python -m black --check .   # line-length 120 (pyproject.toml)
 ```
 
-`uv run pytest ...` etc. also work. New domain code must follow the typed-domain policy in
-`AGENTS.md` (no new stringly-typed league/team/event/card concepts). Add a fixture or
-golden-image snapshot test for every spacing/animation bug fixed.
+`uv run pytest ...` etc. also work. For coverage on the typed `omni/` code, append
+`--cov=omni --cov-branch --cov-report=term-missing` to the pytest run (needs `pytest-cov`,
+pinned in `requirements.dev.txt`) — line coverage alone hides branch gaps, so prefer `--cov-branch`.
+
+New domain code must follow the typed-domain policy in `AGENTS.md` (no new stringly-typed
+league/team/event/card concepts). Add a fixture or golden-image snapshot test for every
+spacing/animation bug fixed.

--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,18 +4,18 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-17)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#4 (agent context, typed core, domain objects, events).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#5 (agent context, typed core, domain objects, events, first card+renderer).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#4 merged and cleaned up** (context, `omni/core/`, `omni/domain/`, `omni/events/`). Feature branches deleted locally and on `origin`.
-- **First card + renderer vertical in progress** on branch `agent/card-renderer`: `omni/cards/` (`ScoreboardCard[Payload]` + `CardKind`/`DisplayTiming`/`LayoutSupport`/`CardPriority` + `LiveBaseballCardPayload`), `omni/panels/geometry.py` (`PanelProfile`→`PanelGeometry`), `omni/renderers/` (hardware-agnostic `Canvas` Protocol with `RecordingCanvas` + `PillowCanvas`, the `Renderer[Payload]` contract, and `LiveBaseballRenderer` for `quad_128x64`). Verified by a draw-op recorder **and** a pixel-exact golden PNG (`tests/golden/`, regen via `OMNI_REGEN_GOLDEN=1`). Green locally. Pending review/merge.
-- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black` as reference sketches. See `docs/dev_setup.md`.
+- **PRs #1–#5 merged and cleaned up.** Feature branches deleted locally and on `origin`.
+- **QC hardening in progress** on branch `agent/qc-hardening`: a quality checkpoint at 5 PRs. Two adversarial audits (spec + tests) + live dogfooding found a real bug-class and branch gaps behind 99% line coverage. Fixes: `HalfInning` enum (kills a silent `half="TOP"`→bottom misrender), `BaseballCount`/score/inning validation, **+18 gap-closing tests**, `font.py` `Any` boundary comment, and `pytest-cov --cov-branch` wired into dev deps + the `test` skill so coverage self-reports. `omni/` at **99%** (5 defensive lines). Green locally. Pending review/merge.
+- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`. See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the card+renderer PR** (branch `agent/card-renderer`).
-- Extend `LiveBaseballRenderer` to **`stack_64x64`** and **`single_64x32`** — each an explicit, golden-tested layout (never a crop of the 128x64 one), exercising the three-profile policy.
-- Then a **provider/CardFactory** (MLB StatsAPI → typed `Contest`/`GameEvent`/`ScoreboardCard`) and the **interleaved card queue + delay buffer** (migration steps 5–7). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
+- **Land the QC PR** (branch `agent/qc-hardening`).
+- **PR #7 — multi-profile renderer** (the one behavioral spec gap): explicit `stack_64x64` + `single_64x32` layouts for the live-baseball card, each with its own golden + draw-op tests (never a crop), consuming `LayoutSupport.fallback_card_kind`/`compromise_notes` (restores doc/code parity). Honors AGENTS.md's "consider all three profiles equally."
+- Then a **provider/CardFactory** (MLB StatsAPI → typed `Contest`/`GameEvent`/`ScoreboardCard`) and the **interleaved card queue + delay buffer**. See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
 
 ## Done
 
@@ -26,3 +26,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #2 merged** — typed-domain core (`omni/core/`); pinned `pytest`, excluded `starter_code/` from lint/type.
 - **PR #3 merged** — typed domain objects (`omni/domain/`: `Competitor`/`Team`/`Contest`).
 - **PR #4 merged** — typed event layer (`omni/events/`: `GameEvent` + per-sport event-type enums).
+- **PR #5 merged** — first card + renderer vertical (`omni/cards`, `omni/panels`, `omni/renderers`; `quad_128x64` + golden snapshot).

--- a/omni/cards/baseball.py
+++ b/omni/cards/baseball.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from omni.cards.base import ScoreboardCard
-from omni.events.baseball import BaseballCount
+from omni.events.baseball import BaseballCount, HalfInning
 
 __all__ = ["BaseballBaseState", "LiveBaseballCardPayload", "LiveBaseballCard"]
 
@@ -26,10 +26,16 @@ class LiveBaseballCardPayload:
     away_score: int
     home_score: int
     inning: int
-    half: str  # "top" / "bottom"; later a HalfInning enum
+    half: HalfInning
     count: BaseballCount
     bases: BaseballBaseState
     last_play: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.away_score < 0 or self.home_score < 0:
+            raise ValueError("scores cannot be negative")
+        if self.inning < 1:
+            raise ValueError("inning must be >= 1")
 
 
 # A live baseball card is a ScoreboardCard carrying the live payload above.

--- a/omni/events/baseball.py
+++ b/omni/events/baseball.py
@@ -10,6 +10,7 @@ from omni.events.base import GameEvent
 
 __all__ = [
     "BaseballGameEventType",
+    "HalfInning",
     "BaseballCount",
     "BaseballPlayPayload",
     "BaseballGameEvent",
@@ -51,6 +52,13 @@ class BaseballGameEventType(StrEnumMixin, str, Enum):
     PERFECT_GAME_BROKEN = "perfect_game_broken"
 
 
+class HalfInning(StrEnumMixin, str, Enum):
+    """Top or bottom of an inning (replaces a stringly-typed ``half``)."""
+
+    TOP = "top"
+    BOTTOM = "bottom"
+
+
 @dataclass(frozen=True, slots=True, kw_only=True)
 class BaseballCount:
     """Balls/strikes/outs at the moment of a play."""
@@ -62,6 +70,9 @@ class BaseballCount:
     def __post_init__(self) -> None:
         if self.balls < 0 or self.strikes < 0 or self.outs < 0:
             raise ValueError("balls, strikes, and outs must be non-negative")
+        # Terminal maxima: 4th ball (walk), 3rd strike (K), 3rd out (inning end).
+        if self.balls > 4 or self.strikes > 3 or self.outs > 3:
+            raise ValueError("balls/strikes/outs exceed their terminal maximums (4/3/3)")
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -73,7 +84,7 @@ class BaseballPlayPayload:
     """
 
     inning: int
-    half: str  # later: HalfInning enum
+    half: HalfInning
     description: str
     count: BaseballCount | None = None
     rbi: int = 0

--- a/omni/renderers/font.py
+++ b/omni/renderers/font.py
@@ -33,7 +33,7 @@ FONTS: dict[str, FontSpec] = {
 
 
 @lru_cache(maxsize=None)
-def _load(name: str) -> Any:
+def _load(name: str) -> Any:  # Any: bdfparser ships no type stubs
     spec = FONTS[name]
     return bdfparser.Font(str(_FONT_DIR / f"{spec.name}.bdf"))
 

--- a/omni/renderers/live_baseball.py
+++ b/omni/renderers/live_baseball.py
@@ -11,6 +11,7 @@ from omni.cards.baseball import LiveBaseballCardPayload
 from omni.core.colors import RGBColor
 from omni.core.enum import PanelProfile
 from omni.domain.contest import TeamGame
+from omni.events.baseball import HalfInning
 from omni.renderers.canvas import Canvas
 from omni.renderers.font import char_size
 
@@ -64,7 +65,7 @@ class LiveBaseballRenderer:
         self._right_text(canvas, _SCORE_RIGHT_X, _HOME_Y, str(payload.home_score), _WHITE, _SCORE_FONT)
 
         # Status panel: inning, count, outs.
-        half = "T" if payload.half == "top" else "B"
+        half = "T" if payload.half is HalfInning.TOP else "B"
         canvas.text(_STATUS_X, 6, f"{half}{payload.inning}", _YELLOW, font=_LABEL_FONT)
         canvas.text(_STATUS_X, 14, f"{payload.count.balls}-{payload.count.strikes}", _WHITE, font=_LABEL_FONT)
         canvas.text(_STATUS_X, 22, f"{payload.count.outs} OUT", _WHITE, font=_LABEL_FONT)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,3 +4,4 @@ jsonschema-default==1.8.1
 black>=24.0
 mypy>=1.8
 pytest>=8.0
+pytest-cov>=5.0

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -31,3 +31,30 @@ def test_pillow_canvas_draws_pixels_and_satisfies_protocol() -> None:
     canvas.set_pixel(7, 3, RGBColor(0, 255, 0))
     assert image.getpixel((7, 3)) == (0, 255, 0)
     canvas.set_pixel(99, 99, RGBColor(0, 0, 255))  # out of bounds: clipped, no error
+
+
+def test_recording_canvas_dimensions_and_set_pixel() -> None:
+    canvas = RecordingCanvas(64, 32)
+    assert (canvas.width, canvas.height) == (64, 32)
+    canvas.set_pixel(3, 4, RGBColor(1, 2, 3))
+    last = canvas.ops[-1]
+    assert last.op == "set_pixel" and (last.x, last.y) == (3, 4)
+
+
+def test_pillow_canvas_text_lights_glyph_pixels() -> None:
+    canvas = PillowCanvas(16, 8)
+    canvas.text(1, 1, "1", RGBColor(255, 255, 255), font="4x6")
+    image = canvas.image()
+    lit = sum(1 for x in range(16) for y in range(8) if image.getpixel((x, y)) == (255, 255, 255))
+    assert lit > 0  # the font path actually rasterized pixels (not via RecordingCanvas)
+    assert image.getpixel((15, 7)) == (0, 0, 0)  # untouched corner stays background
+
+
+def test_pillow_canvas_clips_out_of_bounds_draws() -> None:
+    canvas = PillowCanvas(8, 4)
+    canvas.fill_rect(-3, -3, 100, 100, RGBColor(255, 0, 0))  # oversize rect: fills frame, no error
+    image = canvas.image()
+    assert image.getpixel((0, 0)) == (255, 0, 0)
+    assert image.getpixel((7, 3)) == (255, 0, 0)
+    canvas.text(-50, -50, "1", RGBColor(0, 255, 0), font="4x6")  # fully off-screen: no error/no change
+    assert image.getpixel((0, 0)) == (255, 0, 0)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -64,3 +64,10 @@ def test_scoreboard_card_exposes_league_from_contest() -> None:
     assert card.kind is CardKind.LIVE_GAME
     assert card.priority.band is DisplayPriority.FAVORITE
     assert card.source_event_ids == ()  # default
+
+
+def test_display_timing_without_expiry_is_available_indefinitely() -> None:
+    timing = DisplayTiming(available_at=T, min_display=DurationSeconds(5), max_display=DurationSeconds(30))
+    assert not timing.is_available(T - timedelta(seconds=1))
+    assert timing.is_available(T)
+    assert timing.is_available(T + timedelta(days=3650))  # no expires_at -> available far in the future

--- a/tests/test_cards_baseball.py
+++ b/tests/test_cards_baseball.py
@@ -1,0 +1,36 @@
+"""Tests for omni.cards.baseball payloads: base state, HalfInning, validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from omni.cards.baseball import BaseballBaseState, LiveBaseballCardPayload
+from omni.events.baseball import BaseballCount, HalfInning
+
+_COUNT = BaseballCount(balls=2, strikes=1, outs=2)
+
+
+def test_base_state_defaults_to_empty() -> None:
+    bases = BaseballBaseState()
+    assert (bases.first, bases.second, bases.third) == (False, False, False)
+
+
+def test_live_payload_uses_half_inning_enum() -> None:
+    payload = LiveBaseballCardPayload(
+        away_score=1, home_score=0, inning=3, half=HalfInning.BOTTOM, count=_COUNT, bases=BaseballBaseState()
+    )
+    assert payload.half is HalfInning.BOTTOM
+
+
+def test_live_payload_rejects_negative_scores() -> None:
+    with pytest.raises(ValueError):
+        LiveBaseballCardPayload(
+            away_score=-1, home_score=0, inning=1, half=HalfInning.TOP, count=_COUNT, bases=BaseballBaseState()
+        )
+
+
+def test_live_payload_rejects_inning_below_one() -> None:
+    with pytest.raises(ValueError):
+        LiveBaseballCardPayload(
+            away_score=0, home_score=0, inning=0, half=HalfInning.TOP, count=_COUNT, bases=BaseballBaseState()
+        )

--- a/tests/test_core_enum.py
+++ b/tests/test_core_enum.py
@@ -102,3 +102,10 @@ def test_int_enums_round_trip_through_json_value() -> None:
         assert try_coerce_enum(DisplayPriority, priority.to_json_value()) is priority
     for urgency in UpdateUrgency:
         assert try_coerce_enum(UpdateUrgency, urgency.to_json_value()) is urgency
+
+
+def test_coerce_rejects_unhashable_and_numeric_types() -> None:
+    # Non-str, non-enum inputs hit the TypeError/ValueError arm and fall through to None.
+    assert try_coerce_enum(League, ["mlb"]) is None  # unhashable -> TypeError
+    assert try_coerce_enum(League, 3.5) is None
+    assert try_coerce_enum(League, object()) is None

--- a/tests/test_core_values.py
+++ b/tests/test_core_values.py
@@ -59,3 +59,12 @@ def test_rgb_luminance_and_contrast_extremes() -> None:
     # WCAG max contrast ratio is 21:1, and it is symmetric.
     assert white.contrast_ratio(black) == pytest.approx(21.0)
     assert black.contrast_ratio(white) == pytest.approx(21.0)
+
+
+def test_relative_luminance_covers_both_srgb_branches() -> None:
+    assert RGBColor(255, 255, 255).relative_luminance() == pytest.approx(1.0)
+    assert RGBColor(0, 0, 0).relative_luminance() == pytest.approx(0.0)
+    # power-curve branch (channel > 0.03928): mid-gray ~= 0.216
+    assert RGBColor(128, 128, 128).relative_luminance() == pytest.approx(0.2159, abs=0.002)
+    # linear branch (channel <= 0.03928): near-black stays a small positive value
+    assert 0.0 < RGBColor(2, 2, 2).relative_luminance() < 0.001

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -15,6 +15,7 @@ from omni.events.baseball import (
     BaseballGameEvent,
     BaseballGameEventType,
     BaseballPlayPayload,
+    HalfInning,
 )
 
 T = datetime(2026, 6, 17, 19, 5, tzinfo=timezone.utc)
@@ -67,7 +68,7 @@ def test_baseball_count_rejects_negative() -> None:
 def test_play_payload_keeps_fielder_sequence_structured() -> None:
     payload = BaseballPlayPayload(
         inning=7,
-        half="bottom",
+        half=HalfInning.BOTTOM,
         description="6-4-3 double play",
         count=BaseballCount(balls=1, strikes=2, outs=1),
         fielder_sequence=(6, 4, 3),
@@ -86,7 +87,7 @@ def test_baseball_game_event_is_typed_and_derives_league() -> None:
         source_time=T,
         observed_at=T,
         importance=make_importance(),
-        payload=BaseballPlayPayload(inning=9, half="top", description="walk-off homer", rbi=1),
+        payload=BaseballPlayPayload(inning=9, half=HalfInning.TOP, description="walk-off homer", rbi=1),
     )
     assert isinstance(event, GameEvent)
     assert event.league is League.MLB
@@ -94,3 +95,30 @@ def test_baseball_game_event_is_typed_and_derives_league() -> None:
     assert event.payload.rbi == 1
     assert event.competitors == ()  # default
     assert event.importance.combined_score() > 0
+
+
+def test_importance_accepts_inclusive_0_and_1_boundaries() -> None:
+    imp = make_importance(leverage=0.0, rarity=1.0, favorite_relevance=0.0)
+    assert imp.leverage == 0.0 and imp.rarity == 1.0
+
+
+def test_importance_combined_score_is_monotonic_in_each_component() -> None:
+    base = make_importance(leverage=0.4, rarity=0.4, favorite_relevance=0.4).combined_score()
+    assert make_importance(leverage=0.6, rarity=0.4, favorite_relevance=0.4).combined_score() > base
+    assert make_importance(leverage=0.4, rarity=0.6, favorite_relevance=0.4).combined_score() > base
+    assert make_importance(leverage=0.4, rarity=0.4, favorite_relevance=0.6).combined_score() > base
+
+
+def test_baseball_count_rejects_impossible_values() -> None:
+    BaseballCount(balls=4, strikes=3, outs=3)  # terminal maxima are allowed
+    with pytest.raises(ValueError):
+        BaseballCount(balls=5, strikes=0, outs=0)
+    with pytest.raises(ValueError):
+        BaseballCount(balls=0, strikes=4, outs=0)
+    with pytest.raises(ValueError):
+        BaseballCount(balls=0, strikes=0, outs=4)
+
+
+def test_half_inning_enum_serializes() -> None:
+    assert HalfInning.TOP.to_json_value() == "top"
+    assert HalfInning("bottom") is HalfInning.BOTTOM

--- a/tests/test_renderer_live_baseball.py
+++ b/tests/test_renderer_live_baseball.py
@@ -5,6 +5,7 @@ Regenerate the golden image intentionally with: OMNI_REGEN_GOLDEN=1 pytest -k go
 
 from __future__ import annotations
 
+import dataclasses
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,9 +28,9 @@ from omni.core.enum import DisplayPriority, GameStatus, League, PanelProfile
 from omni.core.ids import LeagueScopedId, SourceRef
 from omni.core.time import DurationSeconds
 from omni.domain.base import LogoAsset
-from omni.domain.contest import TeamGame
+from omni.domain.contest import Contest, TeamGame
 from omni.domain.teams import Team
-from omni.events.baseball import BaseballCount
+from omni.events.baseball import BaseballCount, HalfInning
 from omni.renderers.base import Renderer
 from omni.renderers.canvas import RecordingCanvas
 from omni.renderers.live_baseball import LiveBaseballRenderer
@@ -53,8 +54,8 @@ def _team(team_id: str, name: str, abbr: str, color: RGBColor) -> Team:
     )
 
 
-def make_card() -> ScoreboardCard[LiveBaseballCardPayload]:
-    game = TeamGame(
+def _game() -> TeamGame:
+    return TeamGame(
         id=LeagueScopedId(League.MLB, SOURCE, "g1"),
         league=League.MLB,
         status=GameStatus.LIVE,
@@ -62,24 +63,40 @@ def make_card() -> ScoreboardCard[LiveBaseballCardPayload]:
         away=_team("115", "Colorado Rockies", "COL", RGBColor(51, 0, 111)),
         home=_team("119", "Los Angeles Dodgers", "LAD", RGBColor(0, 90, 156)),
     )
+
+
+def make_card(
+    *,
+    half: HalfInning = HalfInning.TOP,
+    away_score: int = 3,
+    home_score: int = 5,
+    inning: int = 7,
+    bases: BaseballBaseState = BaseballBaseState(first=True),
+) -> ScoreboardCard[LiveBaseballCardPayload]:
     payload = LiveBaseballCardPayload(
-        away_score=3,
-        home_score=5,
-        inning=7,
-        half="top",
+        away_score=away_score,
+        home_score=home_score,
+        inning=inning,
+        half=half,
         count=BaseballCount(balls=2, strikes=1, outs=2),
-        bases=BaseballBaseState(first=True),
+        bases=bases,
     )
     return ScoreboardCard(
         id=CardId("g1:live"),
         kind=CardKind.LIVE_GAME,
-        contest=game,
+        contest=_game(),
         timing=DisplayTiming(available_at=T, min_display=DurationSeconds(5), max_display=DurationSeconds(30)),
         priority=CardPriority(band=DisplayPriority.FAVORITE, score=50.0),
         layout_support=LayoutSupport(profiles=frozenset({PanelProfile.QUAD_128X64})),
         dedupe_key=DedupeKey("g1:live"),
         payload=payload,
     )
+
+
+def _render(card: ScoreboardCard[LiveBaseballCardPayload]) -> RecordingCanvas:
+    canvas = RecordingCanvas(128, 64)
+    LiveBaseballRenderer().render(card, PanelProfile.QUAD_128X64, canvas)
+    return canvas
 
 
 def test_renderer_conforms_to_protocol_and_supports_quad() -> None:
@@ -92,9 +109,20 @@ def test_renderer_rejects_unsupported_profile() -> None:
         LiveBaseballRenderer().render(make_card(), PanelProfile.SINGLE_64X32, RecordingCanvas(64, 32))
 
 
+def test_renderer_rejects_non_teamgame_contest() -> None:
+    contest = Contest(
+        id=LeagueScopedId(League.MLB, SOURCE, "g1"),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=T,
+    )
+    card = dataclasses.replace(make_card(), contest=contest)
+    with pytest.raises(TypeError):
+        LiveBaseballRenderer().render(card, PanelProfile.QUAD_128X64, RecordingCanvas(128, 64))
+
+
 def test_draw_op_layout() -> None:
-    canvas = RecordingCanvas(128, 64)
-    LiveBaseballRenderer().render(make_card(), PanelProfile.QUAD_128X64, canvas)
+    canvas = _render(make_card())
 
     # Background cleared to black first.
     assert canvas.ops[0].op == "fill" and canvas.ops[0].color == RGBColor(0, 0, 0)
@@ -110,6 +138,26 @@ def test_draw_op_layout() -> None:
     assert {(8, 11, "COL"), (8, 43, "LAD")} <= texts  # abbreviations
     assert {(52, 11, "3"), (52, 43, "5")} <= texts  # right-aligned single-digit scores
     assert {(68, 6, "T7"), (68, 14, "2-1"), (68, 22, "2 OUT")} <= texts  # status panel
+
+
+def test_draw_op_bottom_inning_shows_b_label() -> None:
+    texts = {(t.x, t.y, t.text) for t in _render(make_card(half=HalfInning.BOTTOM, inning=9)).texts()}
+    assert (68, 6, "B9") in texts
+
+
+def test_draw_op_two_digit_score_right_aligns() -> None:
+    # "10" is two 6px-wide glyphs, so its left edge is 58 - 12 = 46.
+    texts = {(t.x, t.y, t.text) for t in _render(make_card(away_score=10)).texts()}
+    assert (46, 11, "10") in texts
+
+
+def test_draw_op_empty_bases_draw_dim_outlines() -> None:
+    rects = _render(make_card(bases=BaseballBaseState())).rects()
+    dim = RGBColor(60, 60, 60)
+    # Each empty base is drawn as four 1px DIM edges; no base is filled white 6x6.
+    assert any((r.x, r.y, r.w, r.h) == (108, 16, 6, 1) and r.color == dim for r in rects)  # 1B top edge
+    assert any((r.x, r.y, r.w, r.h) == (100, 6, 6, 1) and r.color == dim for r in rects)  # 2B top edge
+    assert not any(r.w == 6 and r.h == 6 and r.color == RGBColor(255, 255, 255) for r in rects)
 
 
 def _assert_matches_golden(image: Image.Image, name: str) -> None:


### PR DESCRIPTION
## QC hardening — close audit + dogfood findings before building more

A deliberate quality checkpoint at 5 PRs. Two adversarial audits (spec conformance + test quality) plus live dogfooding surfaced a real bug-class and a set of branch gaps hidden behind 99% line coverage. This PR fixes them — **no new features**.

### Correctness
- **`HalfInning` enum** (`omni/events/baseball.py`) replaces the stringly-typed `half: str` on `BaseballPlayPayload` and `LiveBaseballCardPayload`. Dogfooding proved the old `== "top"` compare silently mis-rendered: `half="TOP"` (any value not exactly `"top"`) drew bottom-of-inning. The renderer now compares `is HalfInning.TOP`, and mypy rejects raw strings at the boundary.
- **Tighter validation:** `BaseballCount` rejects impossible counts (balls>4 / strikes>3 / outs>3; terminal maxima allowed); `LiveBaseballCardPayload` rejects negative scores and innings < 1.
- `font.py`: documented the `bdfparser`-stub `Any` boundary (type policy: no `Any` without a boundary comment).

### Tests (+18) — closing the branch gaps the line coverage hid
- **Renderer:** bottom-inning "B" label, empty-base DIM outlines (was the single most-untested path), two-digit right-aligned scores, non-`TeamGame` `TypeError` guard.
- **Boundaries/branches:** `EventImportance` inclusive 0/1 + `combined_score` monotonicity (replaces a vacuous `>0`), `try_coerce_enum` non-str/unhashable, `DisplayTiming(expires_at=None)`, sRGB luminance both branches, `PillowCanvas.text` glyph pixels + out-of-bounds clipping, `RecordingCanvas` dims/set_pixel, baseball-payload validation.

### Repeatable QC
- Added `pytest-cov` to `requirements.dev.txt` and a `--cov=omni --cov-branch --cov-report=term-missing` note to the `test` skill, so branch coverage self-reports from here on (line coverage alone masked these gaps).

### Verification
- `pytest tests/` → **168 passed** (+18)
- `omni/` coverage → **99%** (5 remaining lines are defensive/unreachable: `EnumMixin` base + the Pillow `None`-guard)
- `mypy .` clean (121 files), `black --check .` clean (122 files)

Deferred to **PR #7** (the lone behavioral spec gap): explicit `stack_64x64` + `single_64x32` renderer layouts so the card honors all three panel profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
