### PR TITLE
Close provider → card → renderer (live state + CardFactory)

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,18 +4,18 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-18)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#7 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#8 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#7 merged and cleaned up.** Feature branches deleted locally and on `origin`.
-- **MLB provider boundary in progress** on branch `agent/mlb-provider`: `omni/providers/` adds the `Provider` protocol + `ProviderUpdate`, an `MlbTeamRegistry` (raw StatsAPI team id → typed `BaseballTeam`; 30 clubs, colors from `colors/teams.example.json`), and `MlbStatsApiProvider` parsing the `schedule()` endpoint into typed `TeamGame` contests (matchup, status, start, venue). Raw JSON is confined to `omni/providers/`; the fetcher is injectable so tests use a fixture (`tests/fixtures/providers/mlb_schedule.json`) with **zero network**. Dogfooded **live** against the real API (14 real games, every team resolved, 0 warnings). 205 tests green; `omni/providers` at 100% stmt+branch. Pending review/merge.
+- **PRs #1–#8 merged and cleaned up.** Feature branches deleted locally and on `origin`.
+- **Live game state + CardFactory in progress** on branch `agent/live-state-cardfactory`: closes **provider → card → renderer**. New `omni/domain/baseball.py` holds the baseball value objects (relocated `HalfInning`/`BaseballCount`/`BaseballBaseState`, re-exported from `events`/`cards` for back-compat) plus a `BaseballGameState` snapshot. The MLB provider gains `fetch_game_state(game_pk)` parsing the per-game feed (`statsapi.get("game", ...)` linescore: score/inning/count/bases) into `BaseballGameState`. A new `CardFactory` (`omni/cards/factory.py`) maps `TeamGame` + `BaseballGameState` → a renderable `ScoreboardCard[LiveBaseballCardPayload]`. End-to-end test: both raw fixtures → provider → factory → renderer (runners on first **and** third, beyond the PR #7 golden). Dogfooded: fixture pipeline renders to pixels on all three profiles; the live API correctly **refuses** a non-live game. 229 tests green; new/changed modules at 100% stmt+branch. Pending review/merge.
 - Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the MLB provider PR** (branch `agent/mlb-provider`).
-- **Live game state + CardFactory:** parse the richer StatsAPI per-game feed (`statsapi.get("game", ...)`) into a typed baseball game-state snapshot (`omni/domain/baseball.py`: score/inning/half/count/bases), then a **`CardFactory`** mapping snapshot → `LiveBaseballCardPayload` → `ScoreboardCard`. That closes provider → card → renderer; wire one card into the **emulator** (`run-emulator` skill) for an on-screen end-to-end dogfood.
-- Then the **interleaved card queue + delay buffer** (`DelayBuffer`, `PriorityScorer`, `InterleavedCardQueue`). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
+- **Land the live-state + CardFactory PR** (branch `agent/live-state-cardfactory`).
+- **Emulator / matrix `Canvas` adapter:** bridge omni's `Canvas` protocol to `RGBMatrixEmulator` (and real `rgbmatrix`) + a runnable `omni preview` entry that draws an assembled card on-screen — the Phase-2 `omni preview --profile … --fixture …` DoD and a real on-screen dogfood.
+- Then the **interleaved card queue + delay buffer** (`DelayBuffer`, `PriorityScorer`, `InterleavedCardQueue`): TV-delay sets `available_at`, the scorer fills `CardPriority` (the factory takes an optional priority today). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
 
 ## Done
 
@@ -29,3 +29,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #5 merged** — first card + renderer vertical (`omni/cards`, `omni/panels`, `omni/renderers`; `quad_128x64` + golden).
 - **PR #6 merged** — QC hardening (`HalfInning` enum, validation, +18 gap tests, branch coverage).
 - **PR #7 merged** — multi-profile renderer (`LiveBaseballRenderer` natively renders all three profiles; `single_64x32` is an explicit, tested compromise; `stack_64x64`/`single_64x32` goldens; `assert_never` dispatch).
+- **PR #8 merged** — MLB StatsAPI provider boundary (`omni/providers/`: `Provider`/`ProviderUpdate`, `MlbTeamRegistry`, `schedule()` → typed `TeamGame` contests; fixture-driven, dogfooded live).

--- a/omni/cards/baseball.py
+++ b/omni/cards/baseball.py
@@ -5,18 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from omni.cards.base import ScoreboardCard
-from omni.events.baseball import BaseballCount, HalfInning
+
+# Baseball value objects live in the domain layer; re-exported for back-compat.
+from omni.domain.baseball import BaseballBaseState, BaseballCount, HalfInning
 
 __all__ = ["BaseballBaseState", "LiveBaseballCardPayload", "LiveBaseballCard"]
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class BaseballBaseState:
-    """Base occupancy for rendering the diamond (a player model comes later)."""
-
-    first: bool = False
-    second: bool = False
-    third: bool = False
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/omni/cards/factory.py
+++ b/omni/cards/factory.py
@@ -1,0 +1,80 @@
+"""CardFactory: builds renderable `ScoreboardCard`s from typed domain state.
+
+This is the seam between "what the game is" (domain `BaseballGameState`) and
+"how a card shows it" (a `LiveBaseballCardPayload` plus display metadata). It is
+pure — no I/O, no provider JSON — so it is fully unit-testable.
+
+TV-delay (`available_at` offset) and real priority scoring arrive with the queue
+layer; for now timing starts at `now` and priority defaults to NORMAL.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from omni.cards.base import (
+    CardId,
+    CardKind,
+    CardPriority,
+    DedupeKey,
+    DisplayTiming,
+    LayoutSupport,
+    ScoreboardCard,
+)
+from omni.cards.baseball import LiveBaseballCardPayload
+from omni.core.enum import DisplayPriority, PanelProfile
+from omni.core.time import DurationSeconds
+from omni.domain.baseball import BaseballGameState
+from omni.domain.contest import TeamGame
+
+__all__ = ["CardFactory"]
+
+# The live-baseball renderer natively supports all three profiles (see PR #7).
+_LIVE_BASEBALL_PROFILES = frozenset({PanelProfile.SINGLE_64X32, PanelProfile.STACK_64X64, PanelProfile.QUAD_128X64})
+_DEFAULT_PRIORITY = CardPriority(band=DisplayPriority.NORMAL, score=0.0)
+
+
+@dataclass(frozen=True, slots=True)
+class CardFactory:
+    """Turns domain game state into renderable cards.
+
+    Default min/max on-screen durations are configurable so device profiles can
+    tune dwell time without touching call sites.
+    """
+
+    live_min_display: DurationSeconds = DurationSeconds(8)
+    live_max_display: DurationSeconds = DurationSeconds(30)
+
+    def live_baseball(
+        self,
+        game: TeamGame,
+        state: BaseballGameState,
+        *,
+        now: datetime,
+        priority: CardPriority | None = None,
+    ) -> ScoreboardCard[LiveBaseballCardPayload]:
+        """Build a live MLB card from a matchup + its observed game state."""
+        payload = LiveBaseballCardPayload(
+            away_score=state.away_score,
+            home_score=state.home_score,
+            inning=state.inning,
+            half=state.half,
+            count=state.count,
+            bases=state.bases,
+        )
+        key = f"{game.id.raw}:live"
+        return ScoreboardCard(
+            id=CardId(key),
+            kind=CardKind.LIVE_GAME,
+            contest=game,
+            timing=DisplayTiming(
+                available_at=now,
+                min_display=self.live_min_display,
+                max_display=self.live_max_display,
+            ),
+            priority=priority if priority is not None else _DEFAULT_PRIORITY,
+            layout_support=LayoutSupport(profiles=_LIVE_BASEBALL_PROFILES),
+            dedupe_key=DedupeKey(key),
+            payload=payload,
+        )

--- a/omni/domain/baseball.py
+++ b/omni/domain/baseball.py
@@ -1,0 +1,72 @@
+"""Baseball domain value objects and live game state.
+
+These are foundation types — a half-inning, a balls/strikes/outs count, base
+occupancy, and the live game-state snapshot a provider observes. Events and
+cards build on them, so they live in `domain`; `omni.events.baseball` and
+`omni.cards.baseball` re-export the value types for back-compat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from omni.core.enum import StrEnumMixin
+
+__all__ = ["HalfInning", "BaseballCount", "BaseballBaseState", "BaseballGameState"]
+
+
+class HalfInning(StrEnumMixin, str, Enum):
+    """Top or bottom of an inning (replaces a stringly-typed ``half``)."""
+
+    TOP = "top"
+    BOTTOM = "bottom"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballCount:
+    """Balls/strikes/outs at the moment of a play."""
+
+    balls: int
+    strikes: int
+    outs: int
+
+    def __post_init__(self) -> None:
+        if self.balls < 0 or self.strikes < 0 or self.outs < 0:
+            raise ValueError("balls, strikes, and outs must be non-negative")
+        # Terminal maxima: 4th ball (walk), 3rd strike (K), 3rd out (inning end).
+        if self.balls > 4 or self.strikes > 3 or self.outs > 3:
+            raise ValueError("balls/strikes/outs exceed their terminal maximums (4/3/3)")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballBaseState:
+    """Base occupancy for rendering the diamond (a player model comes later)."""
+
+    first: bool = False
+    second: bool = False
+    third: bool = False
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballGameState:
+    """A live baseball game's observed state: score/inning/half/count/bases.
+
+    This is the domain truth a provider produces from the game feed; a
+    `CardFactory` maps it into a renderable `LiveBaseballCardPayload` (where
+    presentation choices live). Keeping the two separate is the seam between
+    "what the game is" and "how a card shows it".
+    """
+
+    away_score: int
+    home_score: int
+    inning: int
+    half: HalfInning
+    count: BaseballCount
+    bases: BaseballBaseState
+
+    def __post_init__(self) -> None:
+        if self.away_score < 0 or self.home_score < 0:
+            raise ValueError("scores cannot be negative")
+        if self.inning < 1:
+            raise ValueError("inning must be >= 1")

--- a/omni/events/baseball.py
+++ b/omni/events/baseball.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from enum import Enum
 
 from omni.core.enum import StrEnumMixin
+
+# HalfInning/BaseballCount are domain value objects; re-exported here for back-compat.
+from omni.domain.baseball import BaseballCount, HalfInning
 from omni.events.base import GameEvent
 
 __all__ = [
@@ -50,29 +53,6 @@ class BaseballGameEventType(StrEnumMixin, str, Enum):
     NO_HITTER_BROKEN = "no_hitter_broken"
     PERFECT_GAME_ACTIVE = "perfect_game_active"
     PERFECT_GAME_BROKEN = "perfect_game_broken"
-
-
-class HalfInning(StrEnumMixin, str, Enum):
-    """Top or bottom of an inning (replaces a stringly-typed ``half``)."""
-
-    TOP = "top"
-    BOTTOM = "bottom"
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class BaseballCount:
-    """Balls/strikes/outs at the moment of a play."""
-
-    balls: int
-    strikes: int
-    outs: int
-
-    def __post_init__(self) -> None:
-        if self.balls < 0 or self.strikes < 0 or self.outs < 0:
-            raise ValueError("balls, strikes, and outs must be non-negative")
-        # Terminal maxima: 4th ball (walk), 3rd strike (K), 3rd out (inning end).
-        if self.balls > 4 or self.strikes > 3 or self.outs > 3:
-            raise ValueError("balls/strikes/outs exceed their terminal maximums (4/3/3)")
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/omni/providers/mlb_statsapi.py
+++ b/omni/providers/mlb_statsapi.py
@@ -16,14 +16,20 @@ from typing import Any, Callable
 
 from omni.core.enum import GameStatus, League
 from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
 from omni.domain.contest import TeamGame
 from omni.providers.base import ProviderError, ProviderUpdate
 from omni.providers.mlb_teams import MlbTeamRegistry
 
-__all__ = ["MlbStatsApiProvider", "ScheduleFetcher", "map_game_status"]
+__all__ = ["MlbStatsApiProvider", "ScheduleFetcher", "GameFetcher", "map_game_status"]
 
 # (game_date, sport_ids) -> the list of flat schedule rows.
 ScheduleFetcher = Callable[[date, str], list[dict[str, Any]]]
+# game_pk -> the raw nested game feed (statsapi.get("game", ...)).
+GameFetcher = Callable[[Any], dict[str, Any]]
+
+# StatsAPI `inningState` values that mean the bottom half is current/next.
+_BOTTOM_INNING_STATES = frozenset({"Bottom", "End"})
 
 _SOURCE = SourceRef("mlb_statsapi", "https://statsapi.mlb.com")
 
@@ -73,11 +79,13 @@ class MlbStatsApiProvider:
         registry: MlbTeamRegistry,
         fetch_schedule: ScheduleFetcher | None = None,
         *,
+        fetch_game: GameFetcher | None = None,
         source: SourceRef | None = None,
         sport_ids: str = "1,51",  # 1 = MLB, 51 = WBC (mirrors upstream)
     ) -> None:
         self._registry = registry
         self._fetch = fetch_schedule if fetch_schedule is not None else _default_fetch_schedule
+        self._fetch_game = fetch_game if fetch_game is not None else _default_fetch_game
         self.source = source if source is not None else _SOURCE
         self._sport_ids = sport_ids
 
@@ -100,6 +108,19 @@ class MlbStatsApiProvider:
             contests=tuple(contests),
             warnings=tuple(warnings),
         )
+
+    def fetch_game_state(self, game_pk: int | str) -> BaseballGameState:
+        """Fetch one game's live feed and parse it into typed `BaseballGameState`.
+
+        Separate from `refresh` (which is one cheap schedule call): the caller
+        decides which live games are worth a per-game request. Raises
+        `ProviderError` if the fetch fails or the feed has no live state.
+        """
+        try:
+            raw = self._fetch_game(game_pk)
+        except Exception as exc:
+            raise ProviderError(f"MLB game fetch failed for {game_pk}: {exc}") from exc
+        return _parse_game_state(raw)
 
     def _parse_game(self, row: dict[str, Any]) -> TeamGame:
         try:
@@ -137,9 +158,59 @@ def _parse_start(raw: Any, game_pk: Any) -> datetime:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
 
 
+def _half_from_inning_state(inning_state: str) -> HalfInning:
+    # "Middle"/"End" are the breaks after the top/bottom; collapse to our two halves.
+    return HalfInning.BOTTOM if inning_state in _BOTTOM_INNING_STATES else HalfInning.TOP
+
+
+def _parse_game_state(raw: dict[str, Any]) -> BaseballGameState:
+    """Parse a StatsAPI game feed's linescore into typed `BaseballGameState`.
+
+    Base occupancy is read from `offense.{first,second,third}` (a key is present
+    only when that base is occupied), mirroring upstream's `man_on`.
+    """
+    try:
+        line = raw["liveData"]["linescore"]
+        inning = int(line.get("currentInning", 0) or 0)
+        if inning < 1:
+            raise ValueError("game feed has no current inning (not live yet?)")
+        teams = line.get("teams", {})
+        offense = line.get("offense", {})
+        return BaseballGameState(
+            away_score=int(teams.get("away", {}).get("runs", 0) or 0),
+            home_score=int(teams.get("home", {}).get("runs", 0) or 0),
+            inning=inning,
+            half=_half_from_inning_state(str(line.get("inningState", "Top"))),
+            count=BaseballCount(
+                balls=int(line.get("balls", 0) or 0),
+                strikes=int(line.get("strikes", 0) or 0),
+                outs=int(line.get("outs", 0) or 0),
+            ),
+            bases=BaseballBaseState(
+                first="first" in offense,
+                second="second" in offense,
+                third="third" in offense,
+            ),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ProviderError(f"could not parse game state: {exc}") from exc
+
+
 def _default_fetch_schedule(game_date: date, sport_ids: str) -> list[dict[str, Any]]:  # pragma: no cover - real network
     # Lazy import keeps the network library out of `omni` import time and tests.
     import statsapi
 
     result: list[dict[str, Any]] = statsapi.schedule(date=game_date.strftime("%Y-%m-%d"), sportId=sport_ids)
+    return result
+
+
+_GAME_FIELDS = (
+    "liveData,linescore,teams,home,away,runs,currentInning,inningState,balls,strikes,outs,offense,first,second,third"
+)
+
+
+def _default_fetch_game(game_pk: Any) -> dict[str, Any]:  # pragma: no cover - real network
+    import statsapi
+
+    result: dict[str, Any] = statsapi.get("game", {"gamePk": game_pk, "fields": _GAME_FIELDS})
     return result

--- a/tests/fixtures/providers/mlb_game_live.json
+++ b/tests/fixtures/providers/mlb_game_live.json
@@ -1,0 +1,27 @@
+{
+  "gameData": {
+    "teams": {
+      "away": { "id": 115, "abbreviation": "COL" },
+      "home": { "id": 119, "abbreviation": "LAD" }
+    },
+    "status": { "detailedState": "In Progress" }
+  },
+  "liveData": {
+    "linescore": {
+      "currentInning": 7,
+      "inningState": "Top",
+      "teams": {
+        "away": { "runs": 3, "hits": 7, "errors": 0 },
+        "home": { "runs": 5, "hits": 9, "errors": 1 }
+      },
+      "balls": 2,
+      "strikes": 1,
+      "outs": 2,
+      "offense": {
+        "batter": { "id": 500001, "fullName": "A. Batter" },
+        "first": { "id": 500002, "fullName": "R. OnFirst" },
+        "third": { "id": 500003, "fullName": "R. OnThird" }
+      }
+    }
+  }
+}

--- a/tests/test_cards_factory.py
+++ b/tests/test_cards_factory.py
@@ -1,0 +1,86 @@
+"""Tests for the CardFactory: domain state -> renderable ScoreboardCard."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from omni.cards.base import CardKind, CardPriority
+from omni.cards.factory import CardFactory
+from omni.core.enum import DisplayPriority, GameStatus, League, PanelProfile
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.core.time import DurationSeconds
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
+from omni.domain.contest import TeamGame
+from omni.providers.mlb_teams import MlbTeamRegistry
+
+NOW = datetime(2026, 6, 17, 23, 30, tzinfo=timezone.utc)
+T = datetime(2026, 6, 17, 23, 10, tzinfo=timezone.utc)
+SOURCE = SourceRef("mlb_statsapi", "https://statsapi.mlb.com")
+
+
+def _game() -> TeamGame:
+    reg = MlbTeamRegistry.from_color_file()
+    return TeamGame(
+        id=LeagueScopedId(League.MLB, SOURCE, "700001"),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=T,
+        away=reg.resolve(115, full_name="Colorado Rockies"),
+        home=reg.resolve(119, full_name="Los Angeles Dodgers"),
+    )
+
+
+def _state() -> BaseballGameState:
+    return BaseballGameState(
+        away_score=3,
+        home_score=5,
+        inning=7,
+        half=HalfInning.TOP,
+        count=BaseballCount(balls=2, strikes=1, outs=2),
+        bases=BaseballBaseState(first=True, third=True),
+    )
+
+
+def test_live_baseball_card_carries_state_and_metadata() -> None:
+    card = CardFactory().live_baseball(_game(), _state(), now=NOW)
+
+    assert card.kind is CardKind.LIVE_GAME
+    assert card.league is League.MLB
+    assert card.contest is not None and card.contest.id.raw == "700001"
+    assert card.id.raw == "700001:live"
+    assert card.dedupe_key.raw == "700001:live"
+
+    p = card.payload
+    assert (p.away_score, p.home_score) == (3, 5)
+    assert p.inning == 7 and p.half is HalfInning.TOP
+    assert (p.count.balls, p.count.strikes, p.count.outs) == (2, 1, 2)
+    assert p.bases.first and p.bases.third and not p.bases.second
+
+
+def test_default_timing_and_priority() -> None:
+    card = CardFactory().live_baseball(_game(), _state(), now=NOW)
+    assert card.timing.available_at == NOW
+    assert card.timing.min_display == DurationSeconds(8)
+    assert card.timing.max_display == DurationSeconds(30)
+    assert card.timing.is_available(NOW)
+    assert card.priority.band is DisplayPriority.NORMAL
+    assert card.priority.score == 0.0
+
+
+def test_supports_all_three_profiles() -> None:
+    card = CardFactory().live_baseball(_game(), _state(), now=NOW)
+    for profile in PanelProfile:
+        assert card.layout_support.supports(profile)
+
+
+def test_priority_override_is_respected() -> None:
+    high = CardPriority(band=DisplayPriority.HIGH_LEVERAGE, score=88.0, reasons=("close late game",))
+    card = CardFactory().live_baseball(_game(), _state(), now=NOW, priority=high)
+    assert card.priority is high
+
+
+def test_display_durations_are_configurable() -> None:
+    factory = CardFactory(live_min_display=DurationSeconds(3), live_max_display=DurationSeconds(12))
+    card = factory.live_baseball(_game(), _state(), now=NOW)
+    assert card.timing.min_display == DurationSeconds(3)
+    assert card.timing.max_display == DurationSeconds(12)

--- a/tests/test_domain_baseball.py
+++ b/tests/test_domain_baseball.py
@@ -1,0 +1,57 @@
+"""Tests for baseball domain value objects and the live game-state snapshot."""
+
+from __future__ import annotations
+
+import pytest
+
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
+
+
+def _state(**overrides: object) -> BaseballGameState:
+    base: dict[str, object] = dict(
+        away_score=3,
+        home_score=5,
+        inning=7,
+        half=HalfInning.TOP,
+        count=BaseballCount(balls=2, strikes=1, outs=2),
+        bases=BaseballBaseState(first=True, third=True),
+    )
+    base.update(overrides)
+    return BaseballGameState(**base)  # type: ignore[arg-type]
+
+
+def test_game_state_holds_the_snapshot() -> None:
+    state = _state()
+    assert state.away_score == 3 and state.home_score == 5
+    assert state.inning == 7 and state.half is HalfInning.TOP
+    assert state.count.outs == 2
+    assert state.bases.first and state.bases.third and not state.bases.second
+
+
+def test_game_state_rejects_negative_scores() -> None:
+    with pytest.raises(ValueError):
+        _state(away_score=-1)
+    with pytest.raises(ValueError):
+        _state(home_score=-2)
+
+
+def test_game_state_requires_inning_at_least_one() -> None:
+    with pytest.raises(ValueError):
+        _state(inning=0)
+
+
+def test_game_state_is_frozen() -> None:
+    state = _state()
+    with pytest.raises(AttributeError):
+        state.inning = 8  # type: ignore[misc]
+
+
+def test_value_objects_are_shared_across_layers() -> None:
+    # The relocation re-exports from events/cards, so identity is preserved.
+    from omni.cards.baseball import BaseballBaseState as CardsBaseState
+    from omni.events.baseball import BaseballCount as EventsCount
+    from omni.events.baseball import HalfInning as EventsHalf
+
+    assert CardsBaseState is BaseballBaseState
+    assert EventsCount is BaseballCount
+    assert EventsHalf is HalfInning

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -1,0 +1,87 @@
+"""End-to-end: raw StatsAPI fixtures -> provider -> CardFactory -> renderer.
+
+Proves the whole typed pipeline closes — a schedule row becomes a `TeamGame`, a
+game feed becomes a `BaseballGameState`, the factory assembles a card, and the
+renderer draws the fixture's actual state (notably runners on first AND third,
+which the PR #7 golden — first only — does not cover).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from omni.cards.factory import CardFactory
+from omni.core.colors import RGBColor
+from omni.core.enum import GameStatus, League, PanelProfile
+from omni.domain.contest import TeamGame
+from omni.panels.geometry import geometry_for
+from omni.providers.mlb_statsapi import MlbStatsApiProvider
+from omni.providers.mlb_teams import MlbTeamRegistry
+from omni.renderers.canvas import RecordingCanvas
+from omni.renderers.live_baseball import LiveBaseballRenderer
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "providers"
+NOW = datetime(2026, 6, 17, 23, 30, tzinfo=timezone.utc)
+WHITE = RGBColor(255, 255, 255)
+DIM = RGBColor(60, 60, 60)
+
+
+def _provider() -> MlbStatsApiProvider:
+    schedule = json.loads((FIXTURES / "mlb_schedule.json").read_text())
+    game: dict[str, Any] = json.loads((FIXTURES / "mlb_game_live.json").read_text())
+    return MlbStatsApiProvider(
+        MlbTeamRegistry.from_color_file(),
+        fetch_schedule=lambda d, s: schedule,
+        fetch_game=lambda pk: game,
+    )
+
+
+def _assembled_card() -> Any:
+    provider = _provider()
+    update = provider.refresh(NOW)
+    game = next(c for c in update.contests if c.id.raw == "700001")
+    assert isinstance(game, TeamGame) and game.status is GameStatus.LIVE
+    state = provider.fetch_game_state("700001")
+    return CardFactory().live_baseball(game, state, now=NOW)
+
+
+def test_pipeline_produces_a_renderable_mlb_card() -> None:
+    card = _assembled_card()
+    assert card.league is League.MLB
+    assert card.contest.away.abbreviation == "COL"
+    assert card.contest.home.abbreviation == "LAD"
+    assert card.payload.away_score == 3 and card.payload.home_score == 5
+    assert card.payload.bases.first and card.payload.bases.third
+
+
+def test_pipeline_renders_fixture_state_on_quad() -> None:
+    card = _assembled_card()
+    width, height = geometry_for(PanelProfile.QUAD_128X64).size
+    canvas = RecordingCanvas(width, height)
+    LiveBaseballRenderer().render(card, PanelProfile.QUAD_128X64, canvas)
+
+    texts = {(t.x, t.y, t.text) for t in canvas.texts()}
+    assert {(8, 11, "COL"), (8, 43, "LAD")} <= texts
+    assert {(52, 11, "3"), (52, 43, "5")} <= texts
+    assert {(68, 6, "T7"), (68, 14, "2-1"), (68, 22, "2 OUT")} <= texts
+
+    rects = canvas.rects()
+    # First and third occupied -> solid white; second empty -> dim outline, not filled.
+    assert any((r.x, r.y, r.w, r.h) == (108, 16, 6, 6) and r.color == WHITE for r in rects)
+    assert any((r.x, r.y, r.w, r.h) == (92, 16, 6, 6) and r.color == WHITE for r in rects)
+    assert not any((r.x, r.y, r.w, r.h) == (100, 6, 6, 6) and r.color == WHITE for r in rects)
+    assert any((r.x, r.y, r.w, r.h) == (100, 6, 6, 1) and r.color == DIM for r in rects)
+
+
+def test_pipeline_renders_on_all_three_profiles() -> None:
+    card = _assembled_card()
+    for profile in PanelProfile:
+        width, height = geometry_for(profile).size
+        canvas = RecordingCanvas(width, height)
+        LiveBaseballRenderer().render(card, profile, canvas)
+        joined = " ".join(t.text for t in canvas.texts())
+        # Team abbreviations and the inning label appear on every profile.
+        assert "COL" in joined and "LAD" in joined and "T7" in joined

--- a/tests/test_provider_game_state.py
+++ b/tests/test_provider_game_state.py
@@ -1,0 +1,99 @@
+"""Tests for parsing the MLB game feed into typed BaseballGameState."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omni.domain.baseball import HalfInning
+from omni.providers.base import ProviderError
+from omni.providers.mlb_statsapi import (
+    MlbStatsApiProvider,
+    _half_from_inning_state,
+    _parse_game_state,
+)
+from omni.providers.mlb_teams import MlbTeamRegistry
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "providers" / "mlb_game_live.json"
+NOW = datetime(2026, 6, 17, 23, 30, tzinfo=timezone.utc)
+
+
+def _feed() -> dict[str, Any]:
+    data: dict[str, Any] = json.loads(FIXTURE.read_text())
+    return data
+
+
+def test_parse_game_state_from_fixture() -> None:
+    state = _parse_game_state(_feed())
+    assert (state.away_score, state.home_score) == (3, 5)
+    assert state.inning == 7
+    assert state.half is HalfInning.TOP
+    assert (state.count.balls, state.count.strikes, state.count.outs) == (2, 1, 2)
+    # offense had first + third occupied; second empty.
+    assert state.bases.first and state.bases.third and not state.bases.second
+
+
+def test_fetch_game_state_uses_injected_fetcher() -> None:
+    calls: list[Any] = []
+
+    def fetch_game(game_pk: Any) -> dict[str, Any]:
+        calls.append(game_pk)
+        return _feed()
+
+    provider = MlbStatsApiProvider(MlbTeamRegistry({}), fetch_game=fetch_game)
+    state = provider.fetch_game_state(700001)
+    assert calls == [700001]
+    assert state.home_score == 5
+
+
+def test_fetch_game_failure_becomes_provider_error() -> None:
+    def boom(game_pk: Any) -> dict[str, Any]:
+        raise RuntimeError("timeout")
+
+    provider = MlbStatsApiProvider(MlbTeamRegistry({}), fetch_game=boom)
+    with pytest.raises(ProviderError) as exc_info:
+        provider.fetch_game_state(700001)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_empty_bases_when_no_runners() -> None:
+    feed = _feed()
+    feed["liveData"]["linescore"]["offense"] = {"batter": {"id": 1}}
+    state = _parse_game_state(feed)
+    assert not state.bases.first and not state.bases.second and not state.bases.third
+
+
+@pytest.mark.parametrize(
+    "inning_state, expected",
+    [
+        ("Top", HalfInning.TOP),
+        ("Middle", HalfInning.TOP),
+        ("Bottom", HalfInning.BOTTOM),
+        ("End", HalfInning.BOTTOM),
+    ],
+)
+def test_half_from_inning_state(inning_state: str, expected: HalfInning) -> None:
+    assert _half_from_inning_state(inning_state) is expected
+
+
+def test_missing_linescore_raises_provider_error() -> None:
+    with pytest.raises(ProviderError):
+        _parse_game_state({"gameData": {}})
+
+
+def test_not_yet_live_feed_raises_provider_error() -> None:
+    # A scheduled game has currentInning 0 and no live state to render.
+    feed = {"liveData": {"linescore": {"currentInning": 0}}}
+    with pytest.raises(ProviderError):
+        _parse_game_state(feed)
+
+
+def test_impossible_count_raises_provider_error() -> None:
+    feed = _feed()
+    feed["liveData"]["linescore"]["outs"] = 5  # past the terminal maximum
+    with pytest.raises(ProviderError):
+        _parse_game_state(feed)


### PR DESCRIPTION
## What

Completes the typed pipeline from **raw StatsAPI JSON → typed domain → renderable card → pixels**, building on the provider boundary from #8.

- **`omni/domain/baseball.py` (new)** — the baseball value objects (`HalfInning`, `BaseballCount`, `BaseballBaseState`) **relocated** to their natural foundation home, **re-exported** from `omni.events.baseball` / `omni.cards.baseball` so every existing import is unchanged (verified: same object identity across layers). Plus a new **`BaseballGameState`** snapshot (score/inning/half/count/bases) — the domain truth a provider observes.
- **`MlbStatsApiProvider.fetch_game_state(game_pk)`** — parses the per-game feed's linescore (`statsapi.get("game", ...)`) into `BaseballGameState`. Base occupancy comes from `offense.{first,second,third}` (mirroring upstream's `man_on`); `inningState` Middle/End collapse to our two halves. Injectable game fetcher → tests run with **zero network**; raises `ProviderError` on a failed fetch or a not-live feed.
- **`omni/cards/factory.py` (new) `CardFactory`** — maps `TeamGame` + `BaseballGameState` → `ScoreboardCard[LiveBaseballCardPayload]`. This is the **domain/presentation seam**: timing starts at `now`, priority defaults to `NORMAL` (TV-delay's `available_at` offset and real `CardPriority` scoring arrive with the queue; the factory already accepts a priority override).

## Layering note

`BaseballGameState` is **domain** truth, distinct from `LiveBaseballCardPayload` (a presentation shape). Keeping them separate is the seam the `CardFactory` owns. The value-type relocation keeps `domain` as the foundation (it was an incremental artifact that they'd first landed in `events`/`cards`).

## Testing

- New fixture `tests/fixtures/providers/mlb_game_live.json` (trimmed real game-feed shape: COL@LAD, T7, 2-1, 2 out, runners on **first + third**).
- **End-to-end test** drives *both* raw fixtures (schedule + game) through provider → `CardFactory` → `LiveBaseballRenderer`, asserting the rendered first/third bases — coverage the PR #7 golden (first only) didn't have.
- **229 tests green** (+24); new/changed modules at **100% statement + branch**.
- **Dogfooded**: the fixture pipeline renders to pixels on all three profiles (and looks right — COL/LAD stripes, scores, T7/2-1/2 OUT, bases diamond); the **live** API correctly **refuses** a non-live game with a clean `ProviderError`, exercising the real game-feed fetcher.
- `mypy .` and `black --check .` clean.

## Next

Emulator / matrix `Canvas` adapter for an on-screen `omni preview`, then the interleaved card queue + delay buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)