### PR TITLE
On-screen emulator preview + Canvas→matrix adapter

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,18 +4,18 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-18)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#8 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#9 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#8 merged and cleaned up.** Feature branches deleted locally and on `origin`.
-- **Live game state + CardFactory in progress** on branch `agent/live-state-cardfactory`: closes **provider → card → renderer**. New `omni/domain/baseball.py` holds the baseball value objects (relocated `HalfInning`/`BaseballCount`/`BaseballBaseState`, re-exported from `events`/`cards` for back-compat) plus a `BaseballGameState` snapshot. The MLB provider gains `fetch_game_state(game_pk)` parsing the per-game feed (`statsapi.get("game", ...)` linescore: score/inning/count/bases) into `BaseballGameState`. A new `CardFactory` (`omni/cards/factory.py`) maps `TeamGame` + `BaseballGameState` → a renderable `ScoreboardCard[LiveBaseballCardPayload]`. End-to-end test: both raw fixtures → provider → factory → renderer (runners on first **and** third, beyond the PR #7 golden). Dogfooded: fixture pipeline renders to pixels on all three profiles; the live API correctly **refuses** a non-live game. 229 tests green; new/changed modules at 100% stmt+branch. Pending review/merge.
-- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
+- **PRs #1–#9 merged and cleaned up.** Feature branches deleted locally and on `origin`.
+- **Emulator preview + matrix adapter in progress** on branch `agent/emulator-preview`: `omni/renderers/matrix_canvas.py` `MatrixCanvas` bridges the `Canvas` protocol onto any `SetPixel` surface (RGBMatrixEmulator now, real `rgbmatrix` later) and rasterizes **identically** to `PillowCanvas` — a test proves pixel-identity to the goldens on all three profiles. `omni/preview/` adds `build_card_from_scenario` (runs a scenario fixture — schedule row + game feed — through the real provider + factory) and a **`python -m omni.preview --profile … --fixture …`** CLI that draws the card on the emulator (browser at `http://localhost:8888/`). Scenario `fixtures/mlb/live-close-game.json` (tied, bottom 9, bases loaded, full count). Dogfooded: the CLI renders on the live emulator and exits cleanly — the Phase-2 `omni preview` DoD. 242 tests green; new modules at 100%, omni overall 99%. Pending review/merge.
+- Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`; `*/__main__.py` omitted from coverage. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the live-state + CardFactory PR** (branch `agent/live-state-cardfactory`).
-- **Emulator / matrix `Canvas` adapter:** bridge omni's `Canvas` protocol to `RGBMatrixEmulator` (and real `rgbmatrix`) + a runnable `omni preview` entry that draws an assembled card on-screen — the Phase-2 `omni preview --profile … --fixture …` DoD and a real on-screen dogfood.
-- Then the **interleaved card queue + delay buffer** (`DelayBuffer`, `PriorityScorer`, `InterleavedCardQueue`): TV-delay sets `available_at`, the scorer fills `CardPriority` (the factory takes an optional priority today). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
+- **Land the emulator preview PR** (branch `agent/emulator-preview`).
+- **Interleaved card queue + delay buffer** (`omni/queue/`, ROADMAP Phase 4): `DelayBuffer` (TV-delay → a card's `available_at`), `PriorityScorer` (events/state → `CardPriority`, which the factory already accepts), `InterleavedCardQueue` (fair next-card pick across leagues/contests, dedupe via `DedupeKey`, sticky alerts). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
+- Then **MLB P0/P1 polish** (pregame/final cards, fielder sequences, contrast) and league expansion.
 
 ## Done
 
@@ -30,3 +30,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #6 merged** — QC hardening (`HalfInning` enum, validation, +18 gap tests, branch coverage).
 - **PR #7 merged** — multi-profile renderer (`LiveBaseballRenderer` natively renders all three profiles; `single_64x32` is an explicit, tested compromise; `stack_64x64`/`single_64x32` goldens; `assert_never` dispatch).
 - **PR #8 merged** — MLB StatsAPI provider boundary (`omni/providers/`: `Provider`/`ProviderUpdate`, `MlbTeamRegistry`, `schedule()` → typed `TeamGame` contests; fixture-driven, dogfooded live).
+- **PR #9 merged** — live game state + `CardFactory` (`omni/domain/baseball.py` `BaseballGameState`; provider `fetch_game_state`; `omni/cards/factory.py`); closes provider → card → renderer, end-to-end test + dogfood.

--- a/fixtures/mlb/live-close-game.json
+++ b/fixtures/mlb/live-close-game.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "Preview scenario: a tied game, bottom of the 9th, bases loaded, full count. Run with: python -m omni.preview --profile quad_128x64 --fixture fixtures/mlb/live-close-game.json",
+  "schedule": [
+    {
+      "game_id": 700100,
+      "game_datetime": "2026-06-18T23:10:00Z",
+      "game_date": "2026-06-18",
+      "game_type": "R",
+      "status": "In Progress",
+      "away_name": "New York Yankees",
+      "home_name": "Boston Red Sox",
+      "away_id": 147,
+      "home_id": 111,
+      "away_score": 5,
+      "home_score": 5,
+      "current_inning": 9,
+      "inning_state": "Bottom",
+      "venue_id": 3,
+      "venue_name": "Fenway Park"
+    }
+  ],
+  "game": {
+    "gameData": {
+      "teams": {
+        "away": { "id": 147, "abbreviation": "NYY" },
+        "home": { "id": 111, "abbreviation": "BOS" }
+      },
+      "status": { "detailedState": "In Progress" }
+    },
+    "liveData": {
+      "linescore": {
+        "currentInning": 9,
+        "inningState": "Bottom",
+        "teams": {
+          "away": { "runs": 5, "hits": 11, "errors": 0 },
+          "home": { "runs": 5, "hits": 9, "errors": 1 }
+        },
+        "balls": 3,
+        "strikes": 2,
+        "outs": 2,
+        "offense": {
+          "batter": { "id": 600001, "fullName": "W. Walkoff" },
+          "first": { "id": 600002, "fullName": "R. First" },
+          "second": { "id": 600003, "fullName": "R. Second" },
+          "third": { "id": 600004, "fullName": "R. Third" }
+        }
+      }
+    }
+  }
+}

--- a/omni/preview/__init__.py
+++ b/omni/preview/__init__.py
@@ -1,0 +1,12 @@
+"""On-screen preview: assemble a card from a fixture and draw it to the emulator.
+
+`omni.preview.scenario` builds a card from a self-contained scenario fixture
+(schedule row + game feed) through the real provider + factory; `omni.preview.cli`
+renders it onto an `RGBMatrixEmulator` matrix via `MatrixCanvas`.
+"""
+
+from __future__ import annotations
+
+from omni.preview.scenario import build_card_from_scenario
+
+__all__ = ["build_card_from_scenario"]

--- a/omni/preview/__main__.py
+++ b/omni/preview/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for `python -m omni.preview`."""
+
+from __future__ import annotations
+
+from omni.preview.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omni/preview/cli.py
+++ b/omni/preview/cli.py
@@ -1,0 +1,70 @@
+"""`python -m omni.preview` — draw a fixture card on the RGBMatrixEmulator.
+
+    python -m omni.preview --profile quad_128x64 --fixture fixtures/mlb/live-close-game.json
+
+The emulator serves a browser at http://localhost:8888/. By default the preview
+holds until interrupted; pass `--duration N` to exit after N seconds.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+from omni.core.enum import PanelProfile
+from omni.panels.geometry import geometry_for
+from omni.preview.scenario import build_card_from_scenario
+from omni.renderers.live_baseball import LiveBaseballRenderer
+from omni.renderers.matrix_canvas import MatrixCanvas
+
+__all__ = ["main"]
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="omni.preview", description="Preview a card on the LED matrix emulator.")
+    parser.add_argument("--profile", required=True, choices=[profile.value for profile in PanelProfile])
+    parser.add_argument("--fixture", required=True, help="path to a preview scenario JSON (schedule row + game feed)")
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="seconds to hold the frame before exiting; default holds until interrupted",
+    )
+    return parser.parse_args(argv)
+
+
+def _configure_options(options: Any, profile: PanelProfile) -> Any:
+    """Set panel geometry on an RGBMatrixOptions for the profile's logical size.
+
+    Physical multi-panel mapping (e.g. 2x2 64x32 -> 128x64) is real-hardware
+    config; the emulator just needs the logical width/height.
+    """
+    width, height = geometry_for(profile).size
+    options.cols = width
+    options.rows = height
+    options.chain_length = 1
+    options.parallel = 1
+    return options
+
+
+def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - drives the live emulator
+    args = _parse_args(argv)
+    profile = PanelProfile(args.profile)
+    card = build_card_from_scenario(args.fixture, now=datetime.now(timezone.utc))
+
+    from RGBMatrixEmulator import RGBMatrix, RGBMatrixOptions
+
+    width, height = geometry_for(profile).size
+    matrix = RGBMatrix(options=_configure_options(RGBMatrixOptions(), profile))
+    frame = matrix.CreateFrameCanvas()
+    LiveBaseballRenderer().render(card, profile, MatrixCanvas(frame, width, height))
+    matrix.SwapOnVSync(frame)
+
+    import time
+
+    if args.duration is None:
+        while True:
+            time.sleep(1)
+    time.sleep(args.duration)
+    return 0

--- a/omni/preview/scenario.py
+++ b/omni/preview/scenario.py
@@ -1,0 +1,55 @@
+"""Build a renderable card from a self-contained preview scenario fixture.
+
+A scenario JSON bundles a schedule row and its game feed::
+
+    {"schedule": [ <one statsapi.schedule row> ], "game": <statsapi game feed>}
+
+It is run through the real provider + `CardFactory`, so a preview exercises the
+same typed pipeline as production — only the fetchers are swapped for the fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from omni.cards.base import ScoreboardCard
+from omni.cards.baseball import LiveBaseballCardPayload
+from omni.cards.factory import CardFactory
+from omni.domain.contest import TeamGame
+from omni.providers.mlb_statsapi import MlbStatsApiProvider
+from omni.providers.mlb_teams import MlbTeamRegistry
+
+__all__ = ["build_card_from_scenario"]
+
+
+def build_card_from_scenario(
+    path: str | Path,
+    *,
+    now: datetime,
+    registry: MlbTeamRegistry | None = None,
+) -> ScoreboardCard[LiveBaseballCardPayload]:
+    """Assemble a live MLB card from the scenario at `path`.
+
+    The scenario's schedule must contain exactly the game its `game` feed
+    describes; the first parsed `TeamGame` is used.
+    """
+    data: dict[str, Any] = json.loads(Path(path).read_text())
+    schedule = data["schedule"]
+    game_feed = data["game"]
+
+    reg = registry if registry is not None else MlbTeamRegistry.from_color_file()
+    provider = MlbStatsApiProvider(
+        reg,
+        fetch_schedule=lambda game_date, sport_ids: schedule,
+        fetch_game=lambda game_pk: game_feed,
+    )
+
+    contests = [c for c in provider.refresh(now).contests if isinstance(c, TeamGame)]
+    if not contests:
+        raise ValueError(f"scenario {path} produced no team games")
+    game = contests[0]
+    state = provider.fetch_game_state(game.id.raw)
+    return CardFactory().live_baseball(game, state, now=now)

--- a/omni/renderers/matrix_canvas.py
+++ b/omni/renderers/matrix_canvas.py
@@ -1,0 +1,61 @@
+"""A `Canvas` that drives a real LED matrix surface (emulator or hardware).
+
+Bridges omni's hardware-agnostic `Canvas` onto any object exposing the
+rgbmatrix/RGBMatrixEmulator `FrameCanvas` pixel API (`SetPixel`). The rasterizing
+logic mirrors `PillowCanvas` exactly, so what the emulator (or a Pi panel) shows
+is pixel-identical to the golden-image snapshots.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from omni.core.colors import RGBColor
+from omni.renderers.font import rasterize
+
+__all__ = ["MatrixCanvas", "MatrixSurface"]
+
+
+@runtime_checkable
+class MatrixSurface(Protocol):
+    """The slice of the rgbmatrix/emulator canvas API this adapter needs.
+
+    Method name follows the external library (`SetPixel`), not PEP 8.
+    """
+
+    def SetPixel(self, x: int, y: int, r: int, g: int, b: int) -> None: ...
+
+
+class MatrixCanvas:
+    """Draws onto an LED matrix frame canvas; out-of-bounds writes are clipped."""
+
+    def __init__(self, surface: MatrixSurface, width: int, height: int) -> None:
+        self._surface = surface
+        self._w = width
+        self._h = height
+
+    @property
+    def width(self) -> int:
+        return self._w
+
+    @property
+    def height(self) -> int:
+        return self._h
+
+    def fill(self, color: RGBColor) -> None:
+        self.fill_rect(0, 0, self._w, self._h, color)
+
+    def set_pixel(self, x: int, y: int, color: RGBColor) -> None:
+        if 0 <= x < self._w and 0 <= y < self._h:
+            self._surface.SetPixel(x, y, color.r, color.g, color.b)
+
+    def fill_rect(self, x: int, y: int, w: int, h: int, color: RGBColor) -> None:
+        for yy in range(max(0, y), min(self._h, y + h)):
+            for xx in range(max(0, x), min(self._w, x + w)):
+                self._surface.SetPixel(xx, yy, color.r, color.g, color.b)
+
+    def text(self, x: int, y: int, s: str, color: RGBColor, *, font: str = "4x6") -> None:
+        for ry, row in enumerate(rasterize(font, s)):
+            for rx, on in enumerate(row):
+                if on:
+                    self.set_pixel(x + rx, y + ry, color)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "RGBMatrixEmulator.*"
 no_implicit_reexport = false
+
+[tool.coverage.run]
+omit = ["*/__main__.py"]  # `python -m` entry shims; not unit-tested

--- a/tests/test_matrix_canvas.py
+++ b/tests/test_matrix_canvas.py
@@ -1,0 +1,109 @@
+"""Tests for MatrixCanvas: the Canvas -> LED matrix adapter.
+
+The headline test renders a real card through both MatrixCanvas (over a fake
+matrix) and PillowCanvas, and asserts the result is pixel-identical — so the
+emulator/hardware output matches the golden-image snapshots.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from omni.cards.factory import CardFactory
+from omni.core.colors import RGBColor
+from omni.core.enum import GameStatus, League, PanelProfile
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
+from omni.domain.contest import TeamGame
+from omni.panels.geometry import geometry_for
+from omni.providers.mlb_teams import MlbTeamRegistry
+from omni.renderers.live_baseball import LiveBaseballRenderer
+from omni.renderers.matrix_canvas import MatrixCanvas, MatrixSurface
+from omni.renderers.pillow_canvas import PillowCanvas
+
+NOW = datetime(2026, 6, 17, 23, 30, tzinfo=timezone.utc)
+SOURCE = SourceRef("mlb_statsapi", "https://statsapi.mlb.com")
+
+
+class FakeMatrix:
+    """A minimal `MatrixSurface` that records SetPixel writes into a dict."""
+
+    def __init__(self) -> None:
+        self.pixels: dict[tuple[int, int], tuple[int, int, int]] = {}
+
+    def SetPixel(self, x: int, y: int, r: int, g: int, b: int) -> None:
+        self.pixels[(x, y)] = (r, g, b)
+
+
+def _card() -> object:
+    reg = MlbTeamRegistry.from_color_file()
+    game = TeamGame(
+        id=LeagueScopedId(League.MLB, SOURCE, "700001"),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=NOW,
+        away=reg.resolve(115, full_name="Colorado Rockies"),
+        home=reg.resolve(119, full_name="Los Angeles Dodgers"),
+    )
+    state = BaseballGameState(
+        away_score=3,
+        home_score=5,
+        inning=7,
+        half=HalfInning.TOP,
+        count=BaseballCount(balls=2, strikes=1, outs=2),
+        bases=BaseballBaseState(first=True, third=True),
+    )
+    return CardFactory().live_baseball(game, state, now=NOW)
+
+
+def test_fake_matrix_satisfies_surface_protocol() -> None:
+    assert isinstance(FakeMatrix(), MatrixSurface)
+    assert not isinstance(object(), MatrixSurface)
+
+
+def test_set_pixel_clips_to_bounds() -> None:
+    fake = FakeMatrix()
+    canvas = MatrixCanvas(fake, 4, 4)
+    assert (canvas.width, canvas.height) == (4, 4)
+    canvas.set_pixel(1, 2, RGBColor(10, 20, 30))
+    canvas.set_pixel(-1, 0, RGBColor(1, 1, 1))
+    canvas.set_pixel(4, 0, RGBColor(2, 2, 2))
+    canvas.set_pixel(0, 4, RGBColor(3, 3, 3))
+    assert fake.pixels == {(1, 2): (10, 20, 30)}
+
+
+def test_fill_and_fill_rect() -> None:
+    fake = FakeMatrix()
+    canvas = MatrixCanvas(fake, 3, 2)
+    canvas.fill(RGBColor(0, 0, 0))
+    assert len(fake.pixels) == 6  # every pixel written
+    canvas.fill_rect(1, 0, 10, 1, RGBColor(255, 0, 0))  # width clipped to bounds
+    assert fake.pixels[(1, 0)] == (255, 0, 0)
+    assert fake.pixels[(2, 0)] == (255, 0, 0)
+    assert fake.pixels[(0, 0)] == (0, 0, 0)
+
+
+def test_text_draws_some_pixels() -> None:
+    fake = FakeMatrix()
+    MatrixCanvas(fake, 64, 32).text(0, 0, "A", RGBColor(255, 255, 255), font="4x6")
+    assert any(color == (255, 255, 255) for color in fake.pixels.values())
+
+
+def test_matrix_canvas_matches_pillow_pixel_for_pixel() -> None:
+    card = _card()
+    renderer = LiveBaseballRenderer()
+    for profile in PanelProfile:
+        width, height = geometry_for(profile).size
+
+        fake = FakeMatrix()
+        renderer.render(card, profile, MatrixCanvas(fake, width, height))  # type: ignore[arg-type]
+
+        pillow = PillowCanvas(width, height)
+        renderer.render(card, profile, pillow)  # type: ignore[arg-type]
+        image = pillow.image().convert("RGB")
+
+        for y in range(height):
+            for x in range(width):
+                expected = image.getpixel((x, y))
+                actual = fake.pixels.get((x, y), (0, 0, 0))
+                assert actual == expected, f"{profile.value} pixel ({x},{y}): {actual} != {expected}"

--- a/tests/test_preview_scenario.py
+++ b/tests/test_preview_scenario.py
@@ -1,0 +1,76 @@
+"""Tests for the preview scenario builder and CLI helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from omni.core.enum import PanelProfile
+from omni.domain.baseball import HalfInning
+from omni.panels.geometry import geometry_for
+from omni.preview.cli import _configure_options, _parse_args
+from omni.preview.scenario import build_card_from_scenario
+
+CLOSE_GAME = Path(__file__).resolve().parents[1] / "fixtures" / "mlb" / "live-close-game.json"
+NOW = datetime(2026, 6, 18, 23, 30, tzinfo=timezone.utc)
+
+
+def test_build_card_from_close_game_scenario() -> None:
+    card = build_card_from_scenario(CLOSE_GAME, now=NOW)
+    assert card.contest.away.abbreviation == "NYY"  # type: ignore[attr-defined]
+    assert card.contest.home.abbreviation == "BOS"  # type: ignore[attr-defined]
+
+    p = card.payload
+    assert (p.away_score, p.home_score) == (5, 5)
+    assert p.inning == 9 and p.half is HalfInning.BOTTOM
+    assert (p.count.balls, p.count.strikes, p.count.outs) == (3, 2, 2)
+    assert p.bases.first and p.bases.second and p.bases.third  # bases loaded
+
+
+def test_scenario_without_team_games_raises(tmp_path: Path) -> None:
+    scenario = {
+        "schedule": [
+            {
+                "game_id": 1,
+                "game_datetime": "2026-06-18T23:10:00Z",
+                "status": "In Progress",
+                "away_id": 999,  # unknown -> row skipped -> no contests
+                "home_id": 111,
+            }
+        ],
+        "game": {"liveData": {"linescore": {"currentInning": 9}}},
+    }
+    path = tmp_path / "empty.json"
+    path.write_text(json.dumps(scenario))
+    with pytest.raises(ValueError):
+        build_card_from_scenario(path, now=NOW)
+
+
+@pytest.mark.parametrize("profile", list(PanelProfile))
+def test_configure_options_sets_logical_geometry(profile: PanelProfile) -> None:
+    width, height = geometry_for(profile).size
+    options = _configure_options(SimpleNamespace(), profile)
+    assert (options.cols, options.rows) == (width, height)
+    assert options.chain_length == 1
+    assert options.parallel == 1
+
+
+def test_parse_args_reads_profile_fixture_and_duration() -> None:
+    args = _parse_args(["--profile", "stack_64x64", "--fixture", "x.json", "--duration", "5"])
+    assert args.profile == "stack_64x64"
+    assert args.fixture == "x.json"
+    assert args.duration == 5.0
+
+
+def test_parse_args_duration_defaults_to_none() -> None:
+    args = _parse_args(["--profile", "quad_128x64", "--fixture", "x.json"])
+    assert args.duration is None
+
+
+def test_parse_args_rejects_unknown_profile() -> None:
+    with pytest.raises(SystemExit):
+        _parse_args(["--profile", "nope", "--fixture", "x.json"])


### PR DESCRIPTION
## What

Renders an assembled card on a real LED matrix surface, and proves what it shows matches the golden snapshots. This is the Phase-2 **`omni preview`** definition-of-done.

- **`omni/renderers/matrix_canvas.py` (new) `MatrixCanvas`** — bridges the hardware-agnostic `Canvas` protocol onto any object with the rgbmatrix / RGBMatrixEmulator `SetPixel` API (a tiny `MatrixSurface` Protocol). Works with the emulator now and a real Pi `rgbmatrix` `FrameCanvas` later. It rasterizes text/rects **identically** to `PillowCanvas`.
- **`omni/preview/` (new)** — `build_card_from_scenario` runs a self-contained scenario fixture (schedule row + game feed) through the **real provider + `CardFactory`**, so a preview exercises the same typed pipeline as production. `python -m omni.preview --profile P --fixture F` draws the card on the emulator (browser at `http://localhost:8888/`; `--duration` to auto-exit).
- **`fixtures/mlb/live-close-game.json`** — a tied game, bottom of the 9th, bases loaded, full count.

## Testing

- **Pixel-identity test**: renders a card through both `MatrixCanvas` (over a fake matrix) and `PillowCanvas`, asserting the output is **identical pixel-for-pixel on all three profiles** — so the emulator/hardware output provably matches the goldens.
- Adapter unit tests (clipping, fill, fill_rect, text); scenario builder + CLI arg-parsing + options-mapping tests.
- **242 tests green** (+13); new modules at **100%**, omni overall **99%**. `mypy`/`black` clean. Coverage now omits `*/__main__.py` entry shims.

## Dogfood

- `python -m omni.preview --profile quad_128x64 --fixture fixtures/mlb/live-close-game.json` constructs the 128×64 emulator, draws the card, serves at :8888, and exits cleanly.
- Rendered the scenario to PNGs and eyeballed them: quad shows NYY/BOS stripes, 5–5, yellow B9, 3-2, 2 OUT, **bases loaded** (three filled); the 64×32 compromise stays legible (teams + scores + B9).

## Next

The interleaved card queue + delay buffer (`DelayBuffer`/`PriorityScorer`/`InterleavedCardQueue`, ROADMAP Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)