### PR TITLE
Add PriorityScorer: explainable card priority from game state

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,17 +4,17 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-18)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#9 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#10 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#9 merged and cleaned up.** Feature branches deleted locally and on `origin`.
-- **Emulator preview + matrix adapter in progress** on branch `agent/emulator-preview`: `omni/renderers/matrix_canvas.py` `MatrixCanvas` bridges the `Canvas` protocol onto any `SetPixel` surface (RGBMatrixEmulator now, real `rgbmatrix` later) and rasterizes **identically** to `PillowCanvas` — a test proves pixel-identity to the goldens on all three profiles. `omni/preview/` adds `build_card_from_scenario` (runs a scenario fixture — schedule row + game feed — through the real provider + factory) and a **`python -m omni.preview --profile … --fixture …`** CLI that draws the card on the emulator (browser at `http://localhost:8888/`). Scenario `fixtures/mlb/live-close-game.json` (tied, bottom 9, bases loaded, full count). Dogfooded: the CLI renders on the live emulator and exits cleanly — the Phase-2 `omni preview` DoD. 242 tests green; new modules at 100%, omni overall 99%. Pending review/merge.
+- **PRs #1–#10 merged and cleaned up.** Feature branches deleted locally and on `origin`.
+- **Priority scoring in progress** on branch `agent/priority-scorer`: the first piece of the Phase-4 queue (`omni/queue/`). `PriorityScorer.score_live_baseball(game, state)` turns live state into an **explainable** `CardPriority` (band + score + reason codes) per the ROADMAP signal table — favorite team, close & late, high leverage (late + close + runners on), bases loaded, runner in scoring position, full count + two outs. The `CardFactory` already accepts the resulting priority. Pure/deterministic; 10 signal-matrix tests; `omni/queue` at 100%. Dogfooded across a drama spectrum (blowout → walk-off): NORMAL/0 → HIGH_LEVERAGE/97. Pending review/merge.
 - Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`; `*/__main__.py` omitted from coverage. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the emulator preview PR** (branch `agent/emulator-preview`).
-- **Interleaved card queue + delay buffer** (`omni/queue/`, ROADMAP Phase 4): `DelayBuffer` (TV-delay → a card's `available_at`), `PriorityScorer` (events/state → `CardPriority`, which the factory already accepts), `InterleavedCardQueue` (fair next-card pick across leagues/contests, dedupe via `DedupeKey`, sticky alerts). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
+- **Land the priority-scorer PR** (branch `agent/priority-scorer`).
+- **Rest of Phase 4 queue** (`omni/queue/`): `DelayBuffer` (TV-delay → a card's `available_at`; no score spoilers) and `InterleavedCardQueue` (fair next-card pick across leagues/contests, dedupe via `DedupeKey`, sticky alerts). `PriorityScorer` (done) feeds it. See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
 - Then **MLB P0/P1 polish** (pregame/final cards, fielder sequences, contrast) and league expansion.
 
 ## Done
@@ -31,3 +31,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #7 merged** — multi-profile renderer (`LiveBaseballRenderer` natively renders all three profiles; `single_64x32` is an explicit, tested compromise; `stack_64x64`/`single_64x32` goldens; `assert_never` dispatch).
 - **PR #8 merged** — MLB StatsAPI provider boundary (`omni/providers/`: `Provider`/`ProviderUpdate`, `MlbTeamRegistry`, `schedule()` → typed `TeamGame` contests; fixture-driven, dogfooded live).
 - **PR #9 merged** — live game state + `CardFactory` (`omni/domain/baseball.py` `BaseballGameState`; provider `fetch_game_state`; `omni/cards/factory.py`); closes provider → card → renderer, end-to-end test + dogfood.
+- **PR #10 merged** — on-screen emulator preview + `MatrixCanvas` (`Canvas` → LED `SetPixel`, pixel-identical to goldens); `python -m omni.preview --profile … --fixture …`; Phase-2 `omni preview` DoD.

--- a/omni/queue/__init__.py
+++ b/omni/queue/__init__.py
@@ -1,0 +1,12 @@
+"""The display queue (ROADMAP Phase 4): score, delay, and interleave cards.
+
+- `PriorityScorer` turns game state into an explainable `CardPriority`.
+- `DelayBuffer` (later) gates cards by TV-delay so live scores never spoil.
+- `InterleavedCardQueue` (later) picks the next card fairly across contests.
+"""
+
+from __future__ import annotations
+
+from omni.queue.priority import PriorityScorer
+
+__all__ = ["PriorityScorer"]

--- a/omni/queue/priority.py
+++ b/omni/queue/priority.py
@@ -1,0 +1,82 @@
+"""Priority scoring: turn a live game's state into an explainable `CardPriority`.
+
+Per AGENTS.md, priority must not be an unexplained float — every score carries a
+band and human-readable reason codes (ROADMAP's MLB signal table: favorite team,
+close & late, high leverage, runners in scoring position, ...). Live baseball
+only for now; other sports add their own scorers behind the same idea.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omni.cards.base import CardPriority
+from omni.core.enum import DisplayPriority
+from omni.domain.baseball import BaseballGameState
+from omni.domain.contest import TeamGame
+
+__all__ = ["PriorityScorer"]
+
+# Signal weights (points added to the score). Named so priority isn't a magic number.
+_W_FAVORITE = 30.0
+_W_CLOSE_LATE = 25.0
+_W_NINTH_OR_LATER = 10.0
+_W_HIGH_LEVERAGE = 20.0
+_W_BASES_LOADED = 8.0
+_W_SCORING_POSITION = 5.0
+_W_FULL_COUNT_TWO_OUT = 4.0
+
+_LATE_INNING = 7  # 7th inning onward is "late"
+_CLOSE_RUN_DIFF = 1  # within one run is "close"
+
+
+@dataclass(frozen=True, slots=True)
+class PriorityScorer:
+    """Scores live games into a `CardPriority`.
+
+    `favorites` are team abbreviations (e.g. ``frozenset({"COL", "LAD"})``); a
+    typed favorite that also scopes by league can replace this once a second
+    league exists.
+    """
+
+    favorites: frozenset[str] = frozenset()
+
+    def score_live_baseball(self, game: TeamGame, state: BaseballGameState) -> CardPriority:
+        band = DisplayPriority.NORMAL
+        score = 0.0
+        reasons: list[str] = []
+
+        favorite_abbrs = [t.abbreviation for t in (game.away, game.home) if t.abbreviation in self.favorites]
+        if favorite_abbrs:
+            score += _W_FAVORITE
+            band = max(band, DisplayPriority.FAVORITE)
+            reasons.append(f"favorite team {'/'.join(favorite_abbrs)}")
+
+        late = state.inning >= _LATE_INNING
+        close = abs(state.away_score - state.home_score) <= _CLOSE_RUN_DIFF
+        runners_on = state.bases.first or state.bases.second or state.bases.third
+
+        if late and close:
+            score += _W_CLOSE_LATE
+            reasons.append("close & late")
+            if state.inning >= 9:
+                score += _W_NINTH_OR_LATER
+                reasons.append("9th or later")
+
+        if late and close and runners_on:
+            # The game can swing on the next pitch.
+            score += _W_HIGH_LEVERAGE
+            band = max(band, DisplayPriority.HIGH_LEVERAGE)
+            reasons.append("high leverage")
+            if state.bases.first and state.bases.second and state.bases.third:
+                score += _W_BASES_LOADED
+                reasons.append("bases loaded")
+        elif state.bases.second or state.bases.third:
+            score += _W_SCORING_POSITION
+            reasons.append("runner in scoring position")
+
+        if state.count.outs == 2 and state.count.balls == 3 and state.count.strikes == 2:
+            score += _W_FULL_COUNT_TWO_OUT
+            reasons.append("full count, two outs")
+
+        return CardPriority(band=band, score=score, reasons=tuple(reasons))

--- a/tests/test_queue_priority.py
+++ b/tests/test_queue_priority.py
@@ -1,0 +1,138 @@
+"""Tests for the PriorityScorer signal matrix."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from omni.core.enum import DisplayPriority, GameStatus, League
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
+from omni.domain.contest import TeamGame
+from omni.providers.mlb_teams import MlbTeamRegistry
+from omni.queue.priority import PriorityScorer
+
+T = datetime(2026, 6, 17, 23, 10, tzinfo=timezone.utc)
+SOURCE = SourceRef("mlb_statsapi", "https://statsapi.mlb.com")
+_IDS = {"COL": 115, "LAD": 119, "NYY": 147, "BOS": 111}
+_REG = MlbTeamRegistry.from_color_file()
+
+
+def _game(away: str = "COL", home: str = "LAD") -> TeamGame:
+    return TeamGame(
+        id=LeagueScopedId(League.MLB, SOURCE, "g1"),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=T,
+        away=_REG.resolve(_IDS[away]),
+        home=_REG.resolve(_IDS[home]),
+    )
+
+
+def _state(
+    *,
+    away: int = 8,
+    home: int = 3,
+    inning: int = 2,
+    half: HalfInning = HalfInning.TOP,
+    balls: int = 0,
+    strikes: int = 0,
+    outs: int = 0,
+    first: bool = False,
+    second: bool = False,
+    third: bool = False,
+) -> BaseballGameState:
+    return BaseballGameState(
+        away_score=away,
+        home_score=home,
+        inning=inning,
+        half=half,
+        count=BaseballCount(balls=balls, strikes=strikes, outs=outs),
+        bases=BaseballBaseState(first=first, second=second, third=third),
+    )
+
+
+def test_boring_early_game_is_normal_and_unremarkable() -> None:
+    p = PriorityScorer().score_live_baseball(_game(), _state())
+    assert p.band is DisplayPriority.NORMAL
+    assert p.score == 0.0
+    assert p.reasons == ()
+
+
+def test_favorite_team_lifts_band_and_explains_itself() -> None:
+    p = PriorityScorer(favorites=frozenset({"LAD"})).score_live_baseball(_game(), _state())
+    assert p.band is DisplayPriority.FAVORITE
+    assert p.score == 30.0
+    assert any("favorite" in r for r in p.reasons)
+
+
+def test_favorite_matches_away_team_too() -> None:
+    p = PriorityScorer(favorites=frozenset({"COL"})).score_live_baseball(_game(away="COL"), _state())
+    assert p.band is DisplayPriority.FAVORITE
+    assert "COL" in p.reasons[0]
+
+
+def test_close_late_without_runners_stays_normal_band() -> None:
+    p = PriorityScorer().score_live_baseball(_game(), _state(away=4, home=5, inning=8))
+    assert p.band is DisplayPriority.NORMAL  # no runners on -> not yet high leverage
+    assert "close & late" in p.reasons
+    assert p.score == 25.0
+
+
+def test_high_leverage_when_late_close_and_runners_on() -> None:
+    p = PriorityScorer().score_live_baseball(_game(), _state(away=4, home=5, inning=8, second=True))
+    assert p.band is DisplayPriority.HIGH_LEVERAGE
+    assert {"close & late", "high leverage"} <= set(p.reasons)
+
+
+def test_bases_loaded_tie_ninth_is_maximum_drama() -> None:
+    p = PriorityScorer().score_live_baseball(
+        _game(),
+        _state(
+            away=5,
+            home=5,
+            inning=9,
+            half=HalfInning.BOTTOM,
+            balls=3,
+            strikes=2,
+            outs=2,
+            first=True,
+            second=True,
+            third=True,
+        ),
+    )
+    assert p.band is DisplayPriority.HIGH_LEVERAGE
+    assert {"close & late", "9th or later", "high leverage", "bases loaded", "full count, two outs"} <= set(p.reasons)
+    # Sum: close+late 25 + ninth 10 + leverage 20 + loaded 8 + full count 4 = 67
+    assert p.score == 67.0
+
+
+def test_favorite_in_high_leverage_keeps_the_more_urgent_band() -> None:
+    p = PriorityScorer(favorites=frozenset({"COL"})).score_live_baseball(
+        _game(), _state(away=5, home=4, inning=9, third=True)
+    )
+    assert p.band is DisplayPriority.HIGH_LEVERAGE  # 30 > FAVORITE's 20
+    assert any("favorite" in r for r in p.reasons)
+    assert "high leverage" in p.reasons
+
+
+def test_scoring_position_credited_even_when_not_late() -> None:
+    p = PriorityScorer().score_live_baseball(_game(), _state(inning=3, second=True))
+    assert p.band is DisplayPriority.NORMAL
+    assert p.reasons == ("runner in scoring position",)
+    assert p.score == 5.0
+
+
+def test_runner_on_first_only_is_not_scoring_position() -> None:
+    p = PriorityScorer().score_live_baseball(_game(), _state(inning=3, first=True))
+    assert p.reasons == ()
+    assert p.score == 0.0
+
+
+def test_score_is_monotonic_in_drama() -> None:
+    scorer = PriorityScorer()
+    boring = scorer.score_live_baseball(_game(), _state()).score
+    close_late = scorer.score_live_baseball(_game(), _state(away=4, home=5, inning=8)).score
+    high_lev = scorer.score_live_baseball(
+        _game(), _state(away=4, home=5, inning=8, first=True, second=True, third=True)
+    ).score
+    assert boring < close_late < high_lev


### PR DESCRIPTION
## What

The first piece of the **Phase-4 display queue** (`omni/queue/`). Turns a live game's typed state into a `CardPriority` carrying a **band, a score, and human-readable reason codes** — per AGENTS.md, priority must never be an unexplained float.

`PriorityScorer.score_live_baseball(game, state)` weighs the ROADMAP MLB signal table:

| Signal | Effect |
|---|---|
| Favorite team involved | band → FAVORITE, +30, reason names the team |
| Close (≤1 run) & late (≥7th) | +25 (+10 if 9th+) |
| High leverage (late + close + runners on) | band → HIGH_LEVERAGE, +20 |
| Bases loaded | +8 |
| Runner in scoring position (2nd/3rd) | +5 (when not already high-leverage) |
| Full count, two outs | +4 |

The **most urgent applicable band wins** (a favorite in a high-leverage spot is HIGH_LEVERAGE, not just FAVORITE); the score accumulates and every contributing signal is listed in `reasons`. `favorites` are team abbreviations. The `CardFactory` already accepts the resulting priority, so this slots in with no factory change.

## Testing

- **10 signal-matrix tests** covering each signal, band precedence, scoring-position vs. high-leverage, monotonicity (drama ⇒ higher score), and away/home favorite matching.
- `omni/queue` at **100% statement + branch**. 252 tests green overall; `mypy`/`black` clean.
- **Dogfooded** across a spectrum — sensible, explainable output:

```
blowout, 2nd inning            NORMAL          0  —
fav (LAD) blowout, 2nd         FAVORITE       30  favorite team LAD
close, top 8, empty            NORMAL         25  close & late
close, top 8, runner on 2nd    HIGH_LEVERAGE  45  close & late, high leverage
tie, bot 9, loaded, 3-2        HIGH_LEVERAGE  67  close & late, 9th or later, high leverage, bases loaded, full count, two outs
fav, tie bot 9, loaded, 3-2    HIGH_LEVERAGE  97  favorite team LAD, ... (all of the above)
```

## Next

The rest of Phase 4: `DelayBuffer` (TV-delay → `available_at`, no score spoilers) and `InterleavedCardQueue` (fair next-card rotation across contests, dedupe, sticky alerts). `PriorityScorer` feeds the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)