### PR TITLE
Add DelayBuffer: TV-delay holding buffer (no score spoilers)

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,17 +4,17 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-18)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#10 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#11 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview, priority scoring).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#10 merged and cleaned up.** Feature branches deleted locally and on `origin`.
-- **Priority scoring in progress** on branch `agent/priority-scorer`: the first piece of the Phase-4 queue (`omni/queue/`). `PriorityScorer.score_live_baseball(game, state)` turns live state into an **explainable** `CardPriority` (band + score + reason codes) per the ROADMAP signal table — favorite team, close & late, high leverage (late + close + runners on), bases loaded, runner in scoring position, full count + two outs. The `CardFactory` already accepts the resulting priority. Pure/deterministic; 10 signal-matrix tests; `omni/queue` at 100%. Dogfooded across a drama spectrum (blowout → walk-off): NORMAL/0 → HIGH_LEVERAGE/97. Pending review/merge.
+- **PRs #1–#11 merged and cleaned up.** Feature branches deleted locally and on `origin`.
+- **TV-delay buffer in progress** on branch `agent/delay-buffer`: the second Phase-4 queue piece. `DelayBuffer[T]` (`omni/queue/delay_buffer.py`) is a generic holding buffer — `push(item, observed_at=…)` holds it, `release(now)` yields items once their fixed TV-delay has elapsed (in push order), so a unit next to a delayed broadcast never spoils a score. Also `pending()` / `next_release_at()`. Pure/deterministic; 7 tests; `omni/queue` at 100%. Dogfooded: a 30s-delayed HR is held to t=29 and released at t=30. Priority-bypass for ALERT-band cards is left to the queue layer. Pending review/merge.
 - Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`; `*/__main__.py` omitted from coverage. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the priority-scorer PR** (branch `agent/priority-scorer`).
-- **Rest of Phase 4 queue** (`omni/queue/`): `DelayBuffer` (TV-delay → a card's `available_at`; no score spoilers) and `InterleavedCardQueue` (fair next-card pick across leagues/contests, dedupe via `DedupeKey`, sticky alerts). `PriorityScorer` (done) feeds it. See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
+- **Land the delay-buffer PR** (branch `agent/delay-buffer`).
+- **Finish Phase 4** (`omni/queue/`): `InterleavedCardQueue` — fair next-card pick across leagues/contests, dedupe via `DedupeKey`, sticky alerts, priority-bypass of the delay for ALERT-band cards. Consumes `PriorityScorer` (done) + `DelayBuffer` (done). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
 - Then **MLB P0/P1 polish** (pregame/final cards, fielder sequences, contrast) and league expansion.
 
 ## Done
@@ -32,3 +32,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #8 merged** — MLB StatsAPI provider boundary (`omni/providers/`: `Provider`/`ProviderUpdate`, `MlbTeamRegistry`, `schedule()` → typed `TeamGame` contests; fixture-driven, dogfooded live).
 - **PR #9 merged** — live game state + `CardFactory` (`omni/domain/baseball.py` `BaseballGameState`; provider `fetch_game_state`; `omni/cards/factory.py`); closes provider → card → renderer, end-to-end test + dogfood.
 - **PR #10 merged** — on-screen emulator preview + `MatrixCanvas` (`Canvas` → LED `SetPixel`, pixel-identical to goldens); `python -m omni.preview --profile … --fixture …`; Phase-2 `omni preview` DoD.
+- **PR #11 merged** — `PriorityScorer` (`omni/queue/priority.py`): explainable `CardPriority` (band + score + reasons) from live state; first Phase-4 queue piece.

--- a/omni/queue/__init__.py
+++ b/omni/queue/__init__.py
@@ -1,12 +1,13 @@
 """The display queue (ROADMAP Phase 4): score, delay, and interleave cards.
 
 - `PriorityScorer` turns game state into an explainable `CardPriority`.
-- `DelayBuffer` (later) gates cards by TV-delay so live scores never spoil.
+- `DelayBuffer` gates items by TV-delay so live scores never spoil.
 - `InterleavedCardQueue` (later) picks the next card fairly across contests.
 """
 
 from __future__ import annotations
 
+from omni.queue.delay_buffer import DelayBuffer
 from omni.queue.priority import PriorityScorer
 
-__all__ = ["PriorityScorer"]
+__all__ = ["DelayBuffer", "PriorityScorer"]

--- a/omni/queue/delay_buffer.py
+++ b/omni/queue/delay_buffer.py
@@ -1,0 +1,65 @@
+"""TV-delay holding buffer: hold live items so they never spoil a broadcast.
+
+A friends-and-family unit often sits next to a TV that's seconds behind the live
+feed. Pushing every observation through a `DelayBuffer` set to that lag means the
+scoreboard reveals a run/score only once the watcher could have seen it too.
+
+Generic over the held item (a card, an event, a state) so one mechanism serves
+the whole pipeline. The buffer owns delay timing only; priority-based bypass
+(e.g. letting an ALERT skip the delay) is a queue-policy concern layered on top.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Generic, TypeVar
+
+from omni.core.time import DurationSeconds
+
+__all__ = ["DelayBuffer"]
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class _Held(Generic[T]):
+    release_at: datetime
+    item: T
+
+
+class DelayBuffer(Generic[T]):
+    """Holds items for a fixed TV-delay, releasing each once its delay elapses.
+
+    Push items as they are observed; `release(now)` yields those whose delay has
+    elapsed, in the order they were pushed (the delay is fixed, so insertion
+    order is release order). A zero delay releases on the next `release` call.
+    """
+
+    def __init__(self, delay: DurationSeconds) -> None:
+        self._delay = delay
+        self._held: list[_Held[T]] = []
+
+    @property
+    def delay(self) -> DurationSeconds:
+        return self._delay
+
+    def push(self, item: T, *, observed_at: datetime) -> datetime:
+        """Hold `item`; returns when it will become available (`observed_at + delay`)."""
+        release_at = observed_at + self._delay.as_timedelta()
+        self._held.append(_Held(release_at=release_at, item=item))
+        return release_at
+
+    def release(self, now: datetime) -> list[T]:
+        """Pop and return every item whose delay has elapsed (`release_at <= now`)."""
+        ready = [held.item for held in self._held if held.release_at <= now]
+        self._held = [held for held in self._held if held.release_at > now]
+        return ready
+
+    def pending(self) -> int:
+        """How many items are still being held."""
+        return len(self._held)
+
+    def next_release_at(self) -> datetime | None:
+        """When the earliest still-held item becomes available, or None if empty."""
+        return min((held.release_at for held in self._held), default=None)

--- a/tests/test_queue_delay_buffer.py
+++ b/tests/test_queue_delay_buffer.py
@@ -1,0 +1,97 @@
+"""Tests for the TV-delay holding buffer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from omni.core.time import DurationSeconds
+from omni.queue.delay_buffer import DelayBuffer
+
+T0 = datetime(2026, 6, 17, 23, 0, 0, tzinfo=timezone.utc)
+
+
+def _at(seconds: int) -> datetime:
+    return T0 + timedelta(seconds=seconds)
+
+
+def test_zero_delay_releases_on_next_call() -> None:
+    buffer: DelayBuffer[str] = DelayBuffer(DurationSeconds(0))
+    buffer.push("now", observed_at=T0)
+    assert buffer.release(T0) == ["now"]
+    assert buffer.pending() == 0
+
+
+def test_item_is_held_until_the_delay_elapses() -> None:
+    buffer: DelayBuffer[str] = DelayBuffer(DurationSeconds(10))
+    release_at = buffer.push("run scored", observed_at=T0)
+    assert release_at == _at(10)
+
+    assert buffer.release(_at(9)) == []  # still spoiler territory
+    assert buffer.pending() == 1
+    assert buffer.release(_at(10)) == ["run scored"]  # boundary is inclusive
+    assert buffer.pending() == 0
+
+
+def test_released_items_are_not_yielded_twice() -> None:
+    buffer: DelayBuffer[str] = DelayBuffer(DurationSeconds(5))
+    buffer.push("x", observed_at=T0)
+    assert buffer.release(_at(5)) == ["x"]
+    assert buffer.release(_at(10)) == []
+
+
+def test_releases_in_push_order_as_delays_elapse() -> None:
+    buffer: DelayBuffer[str] = DelayBuffer(DurationSeconds(10))
+    buffer.push("a", observed_at=_at(0))  # releases at 10
+    buffer.push("b", observed_at=_at(3))  # releases at 13
+    buffer.push("c", observed_at=_at(3))  # releases at 13
+
+    assert buffer.release(_at(10)) == ["a"]
+    assert buffer.pending() == 2
+    assert buffer.release(_at(13)) == ["b", "c"]  # FIFO among equal release times
+
+
+def test_next_release_at_reports_the_earliest_hold() -> None:
+    buffer: DelayBuffer[int] = DelayBuffer(DurationSeconds(10))
+    assert buffer.next_release_at() is None
+    buffer.push(1, observed_at=_at(5))  # releases at 15
+    buffer.push(2, observed_at=_at(0))  # releases at 10
+    assert buffer.next_release_at() == _at(10)
+    buffer.release(_at(10))
+    assert buffer.next_release_at() == _at(15)
+
+
+def test_delay_is_exposed() -> None:
+    assert DelayBuffer(DurationSeconds(45)).delay == DurationSeconds(45)
+
+
+def test_buffer_holds_a_real_card_until_release() -> None:
+    from omni.cards.factory import CardFactory
+    from omni.core.enum import GameStatus, League
+    from omni.core.ids import LeagueScopedId, SourceRef
+    from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
+    from omni.domain.contest import TeamGame
+    from omni.providers.mlb_teams import MlbTeamRegistry
+
+    reg = MlbTeamRegistry.from_color_file()
+    game = TeamGame(
+        id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "g1"),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=T0,
+        away=reg.resolve(115),
+        home=reg.resolve(119),
+    )
+    state = BaseballGameState(
+        away_score=3,
+        home_score=5,
+        inning=7,
+        half=HalfInning.TOP,
+        count=BaseballCount(balls=0, strikes=0, outs=0),
+        bases=BaseballBaseState(),
+    )
+    card = CardFactory().live_baseball(game, state, now=T0)
+
+    buffer: DelayBuffer[object] = DelayBuffer(DurationSeconds(8))
+    buffer.push(card, observed_at=T0)
+    assert buffer.release(_at(7)) == []
+    assert buffer.release(_at(8)) == [card]


### PR DESCRIPTION
## What

The second **Phase-4 queue** piece (`omni/queue/`). A friends-and-family unit often sits next to a TV that's seconds behind the live feed; pushing every observation through a `DelayBuffer` set to that lag means a run/score is revealed only once the watcher could have seen it too. This is the device-policy spoiler-prevention feature.

`DelayBuffer[T]` is **generic** over the held item (card / event / state) so one mechanism serves the whole pipeline:

- `push(item, observed_at=…)` — holds the item; returns when it releases (`observed_at + delay`).
- `release(now)` — pops and returns every item whose delay has elapsed, **in push order**.
- `pending()` / `next_release_at()` — introspection for the scheduler.

The buffer owns delay timing only; **priority-bypass** (letting an ALERT-band card skip the delay) is a queue-policy concern, deliberately left to the upcoming `InterleavedCardQueue`.

## Testing

- **7 tests**: zero-delay, the inclusive release boundary, no double-yield, push-order/FIFO among equal release times, `next_release_at`, and a **real-card integration** (a `ScoreboardCard` held then released).
- `omni/queue` at **100%**. 259 tests green overall; `mypy`/`black` clean.
- **Dogfood** (30s TV-delay on a home run):

```
t= 0s  pending=1  -> (held — no spoiler)   [releases in 30s]
t=15s  pending=1  -> (held — no spoiler)   [releases in 15s]
t=29s  pending=1  -> (held — no spoiler)   [releases in 1s]
t=30s  pending=0  -> HR! Dodgers lead 6-5
t=31s  pending=0  -> (held — no spoiler)
```

## Next

The last Phase-4 piece: `InterleavedCardQueue` — fair next-card rotation across contests, dedupe via `DedupeKey`, sticky alerts, and priority-bypass of the delay for ALERT-band cards. It consumes `PriorityScorer` + `DelayBuffer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)