### PR TITLE
Add InterleavedCardQueue: fair priority-weighted rotation (Phase 4 capstone)

### DIFF
--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,18 +4,19 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-18)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#11 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview, priority scoring).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#12 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview, priority scoring, TV-delay buffer).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#11 merged and cleaned up.** Feature branches deleted locally and on `origin`.
-- **TV-delay buffer in progress** on branch `agent/delay-buffer`: the second Phase-4 queue piece. `DelayBuffer[T]` (`omni/queue/delay_buffer.py`) is a generic holding buffer — `push(item, observed_at=…)` holds it, `release(now)` yields items once their fixed TV-delay has elapsed (in push order), so a unit next to a delayed broadcast never spoils a score. Also `pending()` / `next_release_at()`. Pure/deterministic; 7 tests; `omni/queue` at 100%. Dogfooded: a 30s-delayed HR is held to t=29 and released at t=30. Priority-bypass for ALERT-band cards is left to the queue layer. Pending review/merge.
+- **PRs #1–#12 merged and cleaned up.** Feature branches deleted locally and on `origin`.
+- **Interleaved card queue in progress** on branch `agent/interleaved-queue` — the **Phase-4 capstone**. `InterleavedCardQueue` (`omni/queue/scheduler.py`) ingests deduped cards (by `DedupeKey`) and `next_card(now, profile)` picks what to show: "most overdue wins" = time-since-last-shown × per-band weight, so favorite/high-leverage contests get more airtime without burying normal ones; ALERT/STICKY cards take over the screen; eligibility honors `available_at`/`expires_at` and profile support. Pure/deterministic; 10 tests + a pipeline-composition test; `omni/queue` at 100%. Dogfooded a full slate: a favorite high-leverage game took 6/12 slots (others 3 each, none buried), and a walk-off ALERT took over entirely. Pending review/merge.
 - Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`; `*/__main__.py` omitted from coverage. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the delay-buffer PR** (branch `agent/delay-buffer`).
-- **Finish Phase 4** (`omni/queue/`): `InterleavedCardQueue` — fair next-card pick across leagues/contests, dedupe via `DedupeKey`, sticky alerts, priority-bypass of the delay for ALERT-band cards. Consumes `PriorityScorer` (done) + `DelayBuffer` (done). See `docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md`, `ROADMAP.md`, `BACKLOG.yaml`.
-- Then **MLB P0/P1 polish** (pregame/final cards, fielder sequences, contrast) and league expansion.
+- **Land the interleaved-queue PR** (branch `agent/interleaved-queue`) — completes **Phase 4**. The typed pipeline is then whole: provider → score → delay → interleave → render, each piece tested + dogfooded.
+- **Running-app orchestration:** wire provider → `DelayBuffer` → `PriorityScorer` → `InterleavedCardQueue` → renderer into an actual refresh/render loop (the live equivalent of `omni preview`), with the dwell loop using each card's `min_display`/`max_display`. Priority-bypass of the delay for ALERT-band cards lives here (orchestration decides what skips the buffer).
+- Then **MLB P0/P1 polish** (pregame/final cards, fielder sequences, contrast) and league expansion (NFL via ESPN provider behind the same `Provider` interface).
+- **Handoff:** an external full review is queued — keep `main` green and STATUS current.
 
 ## Done
 
@@ -33,3 +34,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #9 merged** — live game state + `CardFactory` (`omni/domain/baseball.py` `BaseballGameState`; provider `fetch_game_state`; `omni/cards/factory.py`); closes provider → card → renderer, end-to-end test + dogfood.
 - **PR #10 merged** — on-screen emulator preview + `MatrixCanvas` (`Canvas` → LED `SetPixel`, pixel-identical to goldens); `python -m omni.preview --profile … --fixture …`; Phase-2 `omni preview` DoD.
 - **PR #11 merged** — `PriorityScorer` (`omni/queue/priority.py`): explainable `CardPriority` (band + score + reasons) from live state; first Phase-4 queue piece.
+- **PR #12 merged** — `DelayBuffer[T]` (`omni/queue/delay_buffer.py`): generic TV-delay holding buffer (`push`/`release`); no score spoilers.

--- a/omni/queue/__init__.py
+++ b/omni/queue/__init__.py
@@ -2,12 +2,13 @@
 
 - `PriorityScorer` turns game state into an explainable `CardPriority`.
 - `DelayBuffer` gates items by TV-delay so live scores never spoil.
-- `InterleavedCardQueue` (later) picks the next card fairly across contests.
+- `InterleavedCardQueue` picks the next card fairly across contests.
 """
 
 from __future__ import annotations
 
 from omni.queue.delay_buffer import DelayBuffer
 from omni.queue.priority import PriorityScorer
+from omni.queue.scheduler import InterleavedCardQueue
 
-__all__ = ["DelayBuffer", "PriorityScorer"]
+__all__ = ["DelayBuffer", "InterleavedCardQueue", "PriorityScorer"]

--- a/omni/queue/scheduler.py
+++ b/omni/queue/scheduler.py
@@ -1,0 +1,107 @@
+"""InterleavedCardQueue: fair, priority-weighted rotation across contests.
+
+The capstone of the display pipeline. Cards (already scored and TV-delayed)
+are ingested and deduped by `DedupeKey`; `next_card(now, profile)` decides what
+to show next, balancing two goals:
+
+- **Priority** — favorite / high-leverage cards get more airtime, and
+  ALERT/STICKY cards take over the screen entirely while they're live.
+- **Fairness** — no single contest monopolizes the display; every eligible
+  game still surfaces.
+
+Selection is "most overdue wins": the time since a contest was last shown times
+a per-band weight. A high-priority contest goes overdue faster (so it shows more
+often), but a low-priority one's wait still grows, so it is never buried. With
+few contests this naturally alternates; with many, priority cuts the line.
+
+The queue answers "what next" only — dwell (min/max display) is the caller's
+render loop. True per-league round-robin (vs. per-contest) is a future
+refinement; priority weighting already keeps one busy league from drowning a
+lone high-leverage game elsewhere.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable
+
+from omni.cards.base import ScoreboardCard
+from omni.core.enum import DisplayPriority, PanelProfile
+from omni.core.ids import LeagueScopedId
+
+__all__ = ["InterleavedCardQueue"]
+
+# How much more airtime each band earns (multiplies time-since-last-shown).
+_BAND_WEIGHT: dict[DisplayPriority, int] = {
+    DisplayPriority.BACKGROUND: 1,
+    DisplayPriority.NORMAL: 1,
+    DisplayPriority.FAVORITE: 2,
+    DisplayPriority.HIGH_LEVERAGE: 3,
+    DisplayPriority.ALERT: 4,
+    DisplayPriority.STICKY: 5,
+}
+
+
+class InterleavedCardQueue:
+    """Holds deduped cards and picks the next one to show, fairly and by priority.
+
+    Cards are heterogeneous (different payload types), so they are held as
+    `ScoreboardCard[Any]`; the renderer dispatches on the concrete payload.
+    """
+
+    def __init__(self, *, sticky_band: DisplayPriority = DisplayPriority.ALERT) -> None:
+        self._cards: dict[str, ScoreboardCard[Any]] = {}  # DedupeKey.raw -> card
+        self._sticky_band = sticky_band
+        self._tick = 0
+        self._last_shown: dict[LeagueScopedId, int] = {}
+
+    def ingest(self, card: ScoreboardCard[Any]) -> None:
+        """Add a card, or replace the one sharing its `DedupeKey` (a fresh update)."""
+        self._cards[card.dedupe_key.raw] = card
+
+    def ingest_all(self, cards: Iterable[ScoreboardCard[Any]]) -> None:
+        for card in cards:
+            self.ingest(card)
+
+    def remove(self, dedupe_key: str) -> None:
+        self._cards.pop(dedupe_key, None)
+
+    def prune(self, now: datetime) -> int:
+        """Drop cards whose `expires_at` has passed; returns how many were removed."""
+        expired = [
+            key
+            for key, card in self._cards.items()
+            if card.timing.expires_at is not None and now >= card.timing.expires_at
+        ]
+        for key in expired:
+            del self._cards[key]
+        return len(expired)
+
+    def __len__(self) -> int:
+        return len(self._cards)
+
+    def eligible(self, now: datetime, profile: PanelProfile) -> list[ScoreboardCard[Any]]:
+        """Cards that may show right now on `profile` (available, in-window, supported)."""
+        return [card for card in self._cards.values() if self._showable(card, now, profile)]
+
+    def next_card(self, now: datetime, profile: PanelProfile) -> ScoreboardCard[Any] | None:
+        """Pick and record the next card to display, or None if nothing is eligible."""
+        self.prune(now)
+        pool = self.eligible(now, profile)
+        if not pool:
+            return None
+        # An ALERT/STICKY card takes over the screen while it's live.
+        stickies = [card for card in pool if card.priority.band >= self._sticky_band]
+        chosen = max(stickies or pool, key=self._rank)
+        self._tick += 1
+        self._last_shown[chosen.contest.id] = self._tick
+        return chosen
+
+    def _showable(self, card: ScoreboardCard[Any], now: datetime, profile: PanelProfile) -> bool:
+        return card.timing.is_available(now) and card.layout_support.supports(profile)
+
+    def _rank(self, card: ScoreboardCard[Any]) -> tuple[int, int, float, str]:
+        # most overdue first; ties broken by band, then score, then id (deterministic).
+        staleness = self._tick - self._last_shown.get(card.contest.id, -1)
+        weight = _BAND_WEIGHT.get(card.priority.band, 1)
+        return (staleness * weight, int(card.priority.band), card.priority.score, card.id.raw)

--- a/tests/test_queue_scheduler.py
+++ b/tests/test_queue_scheduler.py
@@ -1,0 +1,156 @@
+"""Tests for the InterleavedCardQueue: dedupe, eligibility, fairness, sticky."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+from omni.cards.base import CardPriority, LayoutSupport, ScoreboardCard
+from omni.cards.baseball import LiveBaseballCardPayload
+from omni.cards.factory import CardFactory
+from omni.core.enum import DisplayPriority, GameStatus, League, PanelProfile
+from omni.core.ids import LeagueScopedId, SourceRef
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, HalfInning
+from omni.domain.contest import TeamGame
+from omni.providers.mlb_teams import MlbTeamRegistry
+from omni.queue.scheduler import InterleavedCardQueue
+
+NOW = datetime(2026, 6, 17, 23, 30, tzinfo=timezone.utc)
+QUAD = PanelProfile.QUAD_128X64
+SOURCE = SourceRef("mlb_statsapi", "https://statsapi.mlb.com")
+_REG = MlbTeamRegistry.from_color_file()
+_STATE = BaseballGameState(
+    away_score=0,
+    home_score=0,
+    inning=1,
+    half=HalfInning.TOP,
+    count=BaseballCount(balls=0, strikes=0, outs=0),
+    bases=BaseballBaseState(),
+)
+
+
+def _card(
+    gid: str,
+    *,
+    band: DisplayPriority = DisplayPriority.NORMAL,
+    score: float = 0.0,
+    profiles: list[PanelProfile] | None = None,
+    available_at: datetime = NOW,
+    expires_at: datetime | None = None,
+) -> ScoreboardCard[LiveBaseballCardPayload]:
+    game = TeamGame(
+        id=LeagueScopedId(League.MLB, SOURCE, gid),
+        league=League.MLB,
+        status=GameStatus.LIVE,
+        scheduled_start=NOW,
+        away=_REG.resolve(115),
+        home=_REG.resolve(119),
+    )
+    card = CardFactory().live_baseball(game, _STATE, now=available_at, priority=CardPriority(band=band, score=score))
+    changes: dict[str, object] = {}
+    if expires_at is not None:
+        changes["timing"] = dataclasses.replace(card.timing, expires_at=expires_at)
+    if profiles is not None:
+        changes["layout_support"] = LayoutSupport(profiles=frozenset(profiles))
+    return dataclasses.replace(card, **changes) if changes else card  # type: ignore[arg-type]
+
+
+def _shown(card: ScoreboardCard[LiveBaseballCardPayload] | None) -> str:
+    assert card is not None
+    return card.contest.id.raw
+
+
+def test_empty_queue_returns_none() -> None:
+    assert InterleavedCardQueue().next_card(NOW, QUAD) is None
+
+
+def test_ingest_dedupes_by_key_latest_wins() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("g1", score=1.0))
+    queue.ingest(_card("g1", score=99.0))  # same dedupe key "g1:live"
+    assert len(queue) == 1
+    chosen = queue.next_card(NOW, QUAD)
+    assert chosen is not None and chosen.priority.score == 99.0
+
+
+def test_profile_support_filters_eligibility() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("g1", profiles=[PanelProfile.QUAD_128X64]))
+    assert queue.next_card(NOW, PanelProfile.SINGLE_64X32) is None
+    assert queue.next_card(NOW, QUAD) is not None
+
+
+def test_card_is_not_shown_before_its_available_at() -> None:
+    queue = InterleavedCardQueue()
+    future = NOW + timedelta(seconds=60)
+    queue.ingest(_card("g1", available_at=future))
+    assert queue.next_card(NOW, QUAD) is None
+    assert queue.next_card(future, QUAD) is not None
+
+
+def test_expired_cards_are_pruned_and_not_shown() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("g1", expires_at=NOW))  # now >= expires_at -> gone
+    assert len(queue) == 1
+    assert queue.next_card(NOW, QUAD) is None
+    assert len(queue) == 0
+
+
+def test_two_equal_cards_alternate_fairly() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("g1"))
+    queue.ingest(_card("g2"))
+    seq = [_shown(queue.next_card(NOW, QUAD)) for _ in range(4)]
+    assert seq[0] != seq[1]  # no monopoly
+    assert seq == [seq[0], seq[1], seq[0], seq[1]]  # stable round-robin
+
+
+def test_high_leverage_gets_more_airtime_among_many() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("hot", band=DisplayPriority.HIGH_LEVERAGE, score=50.0))
+    for i in range(3):
+        queue.ingest(_card(f"n{i}"))
+    counts = Counter(_shown(queue.next_card(NOW, QUAD)) for _ in range(24))
+    # The high-leverage game is shown more often than any single normal game,
+    # but the normal games are not buried (each still appears).
+    assert all(counts["hot"] > counts[f"n{i}"] for i in range(3))
+    assert all(counts[f"n{i}"] > 0 for i in range(3))
+
+
+def test_alert_card_takes_over_the_screen() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("g1"))
+    queue.ingest(_card("g2"))
+    queue.ingest(_card("walkoff", band=DisplayPriority.ALERT, score=100.0))
+    for _ in range(5):
+        assert _shown(queue.next_card(NOW, QUAD)) == "walkoff"
+
+
+def test_rotation_resumes_after_sticky_is_removed() -> None:
+    queue = InterleavedCardQueue()
+    queue.ingest(_card("g1"))
+    queue.ingest(_card("g2"))
+    queue.ingest(_card("walkoff", band=DisplayPriority.ALERT))
+    assert _shown(queue.next_card(NOW, QUAD)) == "walkoff"
+    queue.remove("walkoff:live")
+    resumed = {_shown(queue.next_card(NOW, QUAD)) for _ in range(4)}
+    assert resumed == {"g1", "g2"}
+
+
+def test_scored_and_delayed_cards_compose_through_the_queue() -> None:
+    # A lightweight capstone: priced + delay-released cards rotate in the queue.
+    from omni.core.time import DurationSeconds
+    from omni.queue.delay_buffer import DelayBuffer
+
+    buffer: DelayBuffer[ScoreboardCard[LiveBaseballCardPayload]] = DelayBuffer(DurationSeconds(10))
+    buffer.push(_card("g1"), observed_at=NOW)
+    buffer.push(_card("g2", band=DisplayPriority.FAVORITE, score=30.0), observed_at=NOW)
+
+    queue = InterleavedCardQueue()
+    assert buffer.release(NOW) == []  # still delayed
+    later = NOW + timedelta(seconds=10)
+    queue.ingest_all(buffer.release(later))
+    assert len(queue) == 2
+    # The favorite shows first (higher band breaks the equal-staleness tie).
+    assert _shown(queue.next_card(later, QUAD)) == "g2"


### PR DESCRIPTION
## What

The **capstone of the display pipeline** (ROADMAP Phase 4). Cards — already scored (`PriorityScorer`) and TV-delayed (`DelayBuffer`) — are ingested and deduped by `DedupeKey`; `next_card(now, profile)` decides what to show, balancing two goals:

- **Priority** — favorite / high-leverage cards get more airtime; ALERT/STICKY cards take over the screen while they're live.
- **Fairness** — no single contest monopolizes; every eligible game still surfaces.

Selection is **"most overdue wins"**: time since a contest was last shown × a per-band weight. A high-priority contest goes overdue faster (more airtime), but a low-priority one's wait still grows, so it is never buried. With few contests this naturally alternates; with many, priority cuts the line. Eligibility honors `available_at`, `expires_at` (with `prune`), and profile support. The queue answers "what next" only — dwell (`min/max_display`) is the caller's render loop.

## Testing

- **10 tests**: dedupe (latest wins), empty/eligibility, profile filtering, future `available_at`, expiry+prune, fair alternation, priority weighting (high-leverage shown more, normals not buried), ALERT takeover, rotation-resumes-after-removal — plus a **pipeline-composition test** (score → delay → queue).
- `omni/queue` at **100%** (all four modules). 269 tests green overall; `mypy`/`black` clean.
- **Dogfood** — a full slate through the whole pipeline:

```
COL@LAD blowout    g_lad   band=NORMAL         score=  0
NYY@BOS tie 8th*   g_bos   band=HIGH_LEVERAGE  score= 75  favorite team BOS, close & late, high leverage
SF@SD  mid game    g_sd    band=NORMAL         score=  0

12-slot rotation: bos sd bos lad bos sd bos lad bos sd bos lad
airtime: {bos: 6, sd: 3, lad: 3}   (favorite/high-leverage gets the most; none buried)

walk-off ALERT ingested -> next 4 slots: wo wo wo wo   (takes over the screen)
```

## Phase 4 complete

The typed pipeline is now whole: **provider → score → delay → interleave → render**, each piece tested + dogfooded. Next is the running-app orchestration loop (the live equivalent of `omni preview`), then MLB P0/P1 polish and league expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)