### PR TITLE
docs: handoff refresh — mark shipped milestones, finalize Phase 4 status

### DIFF
--- a/docs/agent_context/BACKLOG.yaml
+++ b/docs/agent_context/BACKLOG.yaml
@@ -1,5 +1,12 @@
 project: omni-scoreboard
-updated: "2026-06-14"
+updated: "2026-06-18"
+progress:
+  note: "PRs #1-#13 shipped milestones M0, M1, M2, M4. STATUS.md is the living state; this file is the forward backlog."
+  shipped_milestones: [M0, M1, M2, M4]
+  deferred_within_shipped:
+    - "M1-003: non-MLB team subclasses (Football/Basketball/Hockey Team) deferred to their league milestones (M6-M9)."
+    - "M4-005: priority-driven polling cadence deferred to the running-app orchestration loop."
+  next: "M3 (MLB P0/P1 polish) + the running-app orchestration loop (wire provider -> delay -> score -> queue -> render live), then M5-M10."
 principles:
   - friends_and_family_scope
   - no_consumer_saas
@@ -29,6 +36,7 @@ milestones:
   - id: M0
     name: repo_reset_local_foundation
     goal: "New omni-scoreboard repo from current upstream; legacy preserved; emulator running."
+    status: shipped
     tasks:
       - id: M0-001
         title: "Rename old fork to omni-scoreboard-legacy"
@@ -56,6 +64,7 @@ milestones:
   - id: M1
     name: typed_domain_core
     goal: "Typed OOP foundation for leagues, teams, contests, events, cards, display profiles."
+    status: shipped  # non-MLB team subclasses (M1-003) deferred to their league milestones
     tasks:
       - id: M1-001
         title: "Add enum mixins and base enums"
@@ -91,6 +100,7 @@ milestones:
   - id: M2
     name: display_profiles_preview_snapshots
     goal: "All three display profiles are first-class and testable."
+    status: shipped
     tasks:
       - id: M2-001
         title: "Implement DisplayProfile and PanelGeometry mapping"
@@ -168,6 +178,7 @@ milestones:
   - id: M4
     name: event_queue_delay_priority
     goal: "Generic event/card engine for all leagues."
+    status: shipped  # M4-005 (priority-driven polling) deferred to the orchestration loop
     tasks:
       - id: M4-001
         title: "Implement DelayBuffer over source_time + tv delay"

--- a/docs/agent_context/STATUS.md
+++ b/docs/agent_context/STATUS.md
@@ -4,19 +4,18 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 
 ## Now (2026-06-18)
 
-- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#12 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview, priority scoring, TV-delay buffer).
+- Revived repo **bootstrapped from upstream MLB-LED-Scoreboard v9.1.5**; `main` = upstream + PRs #1–#13 (agent context, typed core, domain, events, first card+renderer, QC hardening, multi-profile renderer, MLB provider boundary, live-state + CardFactory, on-screen emulator preview, priority scoring, TV-delay buffer, interleaved card queue).
 - Remotes: `origin` = `ajszoke/omni-scoreboard` (HTTPS), `upstream` = `MLB-LED-Scoreboard/mlb-led-scoreboard` (branch `master`), `legacy` = `ajszoke/omni-scoreboard-legacy` (pre-revival Omni work: `legacy/master`, `legacy/dev`).
-- **PRs #1–#12 merged and cleaned up.** Feature branches deleted locally and on `origin`.
-- **Interleaved card queue in progress** on branch `agent/interleaved-queue` — the **Phase-4 capstone**. `InterleavedCardQueue` (`omni/queue/scheduler.py`) ingests deduped cards (by `DedupeKey`) and `next_card(now, profile)` picks what to show: "most overdue wins" = time-since-last-shown × per-band weight, so favorite/high-leverage contests get more airtime without burying normal ones; ALERT/STICKY cards take over the screen; eligibility honors `available_at`/`expires_at` and profile support. Pure/deterministic; 10 tests + a pipeline-composition test; `omni/queue` at 100%. Dogfooded a full slate: a favorite high-leverage game took 6/12 slots (others 3 each, none buried), and a walk-off ALERT took over entirely. Pending review/merge.
+- **PRs #1–#13 merged and cleaned up.** Feature branches deleted locally and on `origin`. `main` is green and between feature PRs (a docs-only `agent/handoff-backlog-refresh` branch carries this update).
+- **Phase 4 complete — the typed pipeline is whole:** provider → score → delay → interleave → render, each stage typed, tested, and dogfooded. 269 tests; `omni/` ~99% (queue/providers/factory 100% incl. branch); `mypy`/`black` clean. **Handoff-ready** for an external full review.
 - Dev env: **uv + `.venv`** (Py 3.12); emulator runs headless (`http://localhost:8888/`). `pytest`/`pytest-cov` pinned in `requirements.dev.txt`; `starter_code/` excluded from `mypy`/`black`; `*/__main__.py` omitted from coverage. Coverage: `--cov=omni --cov-branch` (see `test` skill). See `docs/dev_setup.md`.
 - Physical **`quad_128x64` reference board** is live on the LAN running the pre-revival code; reachable from WSL (`ssh omni-board`). Details in `CLAUDE.local.md`. Deploying the revived repo to it is future work.
 
 ## Next
 
-- **Land the interleaved-queue PR** (branch `agent/interleaved-queue`) — completes **Phase 4**. The typed pipeline is then whole: provider → score → delay → interleave → render, each piece tested + dogfooded.
+- **Handoff:** external full review (`/code-review ultra`, user-launched) is the immediate step — `main` is green and the docs are current.
 - **Running-app orchestration:** wire provider → `DelayBuffer` → `PriorityScorer` → `InterleavedCardQueue` → renderer into an actual refresh/render loop (the live equivalent of `omni preview`), with the dwell loop using each card's `min_display`/`max_display`. Priority-bypass of the delay for ALERT-band cards lives here (orchestration decides what skips the buffer).
-- Then **MLB P0/P1 polish** (pregame/final cards, fielder sequences, contrast) and league expansion (NFL via ESPN provider behind the same `Provider` interface).
-- **Handoff:** an external full review is queued — keep `main` green and STATUS current.
+- Then **MLB P0/P1 polish** (M3: pregame/final cards, fielder sequences, contrast) and league expansion (M6 NFL via an ESPN provider behind the same `Provider` interface).
 
 ## Done
 
@@ -35,3 +34,4 @@ _Living status doc. Keep it short; update whenever project state changes (branch
 - **PR #10 merged** — on-screen emulator preview + `MatrixCanvas` (`Canvas` → LED `SetPixel`, pixel-identical to goldens); `python -m omni.preview --profile … --fixture …`; Phase-2 `omni preview` DoD.
 - **PR #11 merged** — `PriorityScorer` (`omni/queue/priority.py`): explainable `CardPriority` (band + score + reasons) from live state; first Phase-4 queue piece.
 - **PR #12 merged** — `DelayBuffer[T]` (`omni/queue/delay_buffer.py`): generic TV-delay holding buffer (`push`/`release`); no score spoilers.
+- **PR #13 merged** — `InterleavedCardQueue` (`omni/queue/scheduler.py`): fair, priority-weighted rotation across contests (dedupe, sticky alerts, profile-aware); **completes Phase 4**.


### PR DESCRIPTION
Docs-only prep for the external full review. PRs #1–#13 are merged and **Phase 4 is complete**, but the backlog still listed delivered work as open tasks.

- **`BACKLOG.yaml`**: adds a `progress` block (shipped M0/M1/M2/M4, the two deferrals within them, and what's next), marks those milestones `status: shipped`, and bumps `updated` to 2026-06-18. Validated with PyYAML.
- **`STATUS.md`**: flips #13 to Done, records Phase 4 complete (provider → score → delay → interleave → render), and notes `main` is green and handoff-ready.

No code change.

## State at handoff

- **13 PRs merged**; the typed pipeline is whole and each stage is tested + dogfooded.
- **269 tests**, `omni/` ~99% (queue/providers/factory 100% incl. branch), `mypy`/`black` clean.
- Remaining: M3 (MLB P0/P1 polish), the running-app orchestration loop, then M5–M10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)