### PR TITLE
Add external-review infrastructure: frozen kernel + review skill

### DIFF
--- a/.claude/skills/external-review/SKILL.md
+++ b/.claude/skills/external-review/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: external-review
+description: Run a round of the head/hand external review — bundle the build state for the external flagship model (ChatGPT, "CGPT") to review fidelity-to-plan and steer the next phase, using the plan-trio + round-zip cadence. Use after a milestone/phase, before a framework-level direction change, or whenever the build needs the planner to bless deviations or sequence what's next. Produces a scannable plan-trio in ~/.claude/plans/ and an immutable round-N.zip + prompt to hand off. NOT for routine PRs, bug fixes, or single-file edits.
+---
+
+# External-review cadence (head/hand, plan-trio + round-zips)
+
+This project runs a **head / hand** split:
+
+- **Head (planner):** the external flagship model (ChatGPT, "CGPT" / "external"). Owns conceptual
+  reasoning, long-horizon planning, and design/fidelity review. It seeded the kernel
+  (`docs/agent_context/kernel/`, frozen) and reviews each round's bundle.
+- **Hand (implementer):** Claude Code (you). Carry out the build, **self-review against the kernel**,
+  fix clear drifts yourself, and bundle each round for the head to review and re-plan.
+
+A round packages the current build state into an immutable `round-N.zip` + a `round-N-prompt.md` the
+**user** pastes/uploads to the flagship; the flagship returns a verdict + next-phase plan, which you
+adjudicate and fold in. Adapted from the day-job `external-review` skill (Shopfine). Detail in
+[reference.md](reference.md); skeletons in [templates.md](templates.md).
+
+## When to run a round (and not)
+
+| Run a round | Don't |
+|---|---|
+| After a phase/milestone — "was the build faithful; what's next?" | Routine PRs, bug fixes, single-file edits |
+| Before a framework-level direction change or a big sequencing call | Mechanical refactors / renames / typos |
+| When deviations from the kernel need the planner to bless or redirect | Anything where the right next step is already clear |
+| Locking a multi-file design before building it | Backfills / test tweaks |
+
+Always state explicitly what's **current-ship** vs **deferred** and ask the head to confirm the split. Don't overengineer; a clean green light ends the cadence.
+
+## The artifacts
+
+```
+~/.claude/plans/
+  omni-<slug>.md             ← main plan / review brief, stays SCANNABLE
+  omni-<slug>-SUPPLEMENT.md  ← evidence locker: file:line touchpoints, in-code verifications, drift table
+  omni-<slug>-REVIEWS.md     ← per-round log: briefing + verbatim verdict + our adjudication
+~/scratchpad/omni-scoreboard/
+  round-N-prompt.md          ← the briefing handed to the flagship (also bundled)
+  round-N.zip                ← plans/ snapshot + prompt + sources/ + prior verdict
+  round-N-verdict.md         ← the flagship's verbatim verdict, archived per round
+```
+
+`<slug>` is a stable memorable handle. **One zip per round, never overwrite — it's the audit trail.**
+Copy the final `round-N.zip` + `round-N-prompt.md` to a user-reachable spot (e.g. a Windows
+`Downloads/omni_review_round-N/` folder) so the user can upload them to the flagship.
+
+## The loop
+
+1. **Self-review against the kernel first.** Diff the as-built repo (`omni/`, `AGENTS.md`, `docs/`)
+   against the frozen `docs/agent_context/kernel/`. Catalog every drift: **faithful**, **deliberate
+   deviation (defend it)**, or **accidental (fix it)**. Verify load-bearing claims in-code, cite
+   `file:line`, and distinguish **[verified]** (read this session) from **[reported]**.
+2. **Fix the clear drifts yourself** (own PRs) before the round — don't ask the head to adjudicate
+   what you can just correct (e.g. a doc that describes modules that don't exist). Leave the
+   judgment calls (architecture axis, sequencing) for the head.
+3. **Write the plan-trio** ([templates.md](templates.md)): main brief (scannable), SUPPLEMENT
+   (drift table + in-code verifications), REVIEWS skeleton.
+4. **Author `round-N-prompt.md`.** Round 1 is fidelity + open-ended planning: state the posture,
+   summarize what was built vs. the kernel, present the drift catalog with your disposition on each,
+   and ask the head to (a) confirm fidelity, (b) bless or redirect each deliberate deviation, and
+   (c) plan/sequence the next phase. Later rounds report what changed and converge.
+5. **Bundle `round-N.zip`** — `plans/` snapshot + the prompt + `sources/` (the frozen kernel, current
+   `AGENTS.md`/`STATUS.md`/`ARCHITECTURE`, the `omni/` tree, key modules the brief cites ≤~5k lines,
+   a test/coverage snapshot) + the prior round's verbatim verdict. **Verify contents** (`zipinfo -1`)
+   before handing off.
+6. **Hand off → the user runs the flagship → pastes the verbatim verdict back.** You cannot launch
+   the flagship yourself.
+7. **Record + adjudicate** in REVIEWS: archive the verdict verbatim (`round-N-verdict.md`), then per
+   finding write **accept / defer / disagree-with-rationale** + a severity tag; capture the head's own
+   open questions with a disposition.
+8. **Verify the head's load-bearing claims in-code before folding them in** — re-read every `file:line`
+   it leans on; confirm, downgrade, or refute each.
+9. **Fold accepted findings + the next-phase plan into the trio + STATUS.** Then implement per the
+   normal PR + QC workflow.
+10. **Closure check.** Clean "Proceed" + no open framing questions → converge, don't manufacture
+    rounds. Otherwise build `round-(N+1).zip` and loop from step 6.
+
+## Standing rules (every round)
+
+- **Verbatim, always.** The flagship's verdict goes into `round-N-verdict.md` unedited — audit trail.
+- **Verify before you trust.** Re-read every `file:line` either side leans on.
+- **Never overwrite a round.** Each `round-N.zip` is immutable history.
+- **Never edit the kernel.** `docs/agent_context/kernel/` is the frozen baseline; drift is surfaced,
+  not silently reconciled away.
+- **Track state in memory.** Keep a `project_omni_review.md` auto-memory pointing at the trio + current
+  round + the key reframings, so a future session resumes cleanly.
+- **Right-size.** Round count scales with risk; a clean green light ends it.
+
+See [reference.md](reference.md) for the full layout/sources/prompt-anatomy spec and [templates.md](templates.md) for skeletons.

--- a/.claude/skills/external-review/reference.md
+++ b/.claude/skills/external-review/reference.md
@@ -1,0 +1,121 @@
+# External-review cadence — reference
+
+Detailed conventions for the [external-review](SKILL.md) skill. Skeletons in [templates.md](templates.md).
+
+---
+
+## 1. The plan-trio (`~/.claude/plans/`)
+
+Three sibling files sharing an `omni-<slug>` handle. The split keeps the main brief scannable.
+
+| File | Holds | Keep it… |
+|---|---|---|
+| `omni-<slug>.md` | The review brief / plan: posture, what was built vs. the kernel, the drift catalog with dispositions, scope (current-ship vs deferred), the questions for the head, next-phase proposal | **Scannable.** The head should grok the shape in 2 minutes. |
+| `omni-<slug>-SUPPLEMENT.md` | The evidence locker: the full **drift table** (kernel item → as-built → verdict), `file:line` touchpoints, in-code verifications, test/coverage data | Dense is fine. |
+| `omni-<slug>-REVIEWS.md` | One section per round: briefing summary, **verbatim verdict**, per-finding decisions, the head's open questions, convergence checklist | Append-only across rounds. |
+
+Tag claims **[verified]** (read this session) vs **[reported]** (secondhand) in the SUPPLEMENT.
+
+---
+
+## 2. The round-zip (`~/scratchpad/omni-scoreboard/`)
+
+```
+round-N-prompt.md     ← authored FIRST, then a copy is bundled
+round-N-verdict.md    ← the flagship's verbatim verdict (archived after the round)
+round-N.zip           ← plans/ (trio snapshot) + sources/ + round-N-prompt.md + round-(N-1)-verdict.md
+```
+
+- **1-indexed, no timestamps** — the round number is the version. **Never overwrite a round.**
+- Build with `zip -r -q round-N.zip plans/ sources/ round-N-prompt.md`. **Verify** with `zipinfo -1`
+  before handing off: the trio snapshot must be current and no junk leaked in.
+- Copy the final zip + prompt to a **user-reachable** location (e.g. `/mnt/c/Users/<user>/Downloads/
+  omni_review_round-N/`) so the user can upload them to the flagship.
+
+---
+
+## 3. Selecting `sources/`
+
+Bundle what lets the head reason from the actual repo, not training-data guesses:
+
+- **The frozen kernel** (`docs/agent_context/kernel/`) — the baseline it's judging fidelity against.
+- **Current living docs:** `AGENTS.md`, `docs/agent_context/STATUS.md`, `ROADMAP.md`, the *as-built*
+  `ARCHITECTURE_TYPED_DOMAIN.md`, `BACKLOG.yaml`.
+- **The `omni/` tree** (`find omni -name '*.py'`) and the **key modules the brief cites** (full files
+  ≤ ~5k lines — let the head navigate, don't excerpt).
+- **A test/quality snapshot** — `pytest` summary, `mypy`/`black` status, `--cov=omni --cov-branch`
+  numbers — as a `.md`, pre-empting "is it actually tested?".
+- When iterating, the **prior round's verbatim verdict**.
+- Round 2+ typically *adds* the specific files the head asked for, carried alongside round-1 sources.
+
+Exclude bulk/opaque junk and anything git-ignored (secrets, `config.json`, `.venv/`).
+
+---
+
+## 4. Anatomy of a good `round-N-prompt.md`
+
+**Round 1 — fidelity + open-ended planning.** You want the framing pressure-tested, not a rubber stamp.
+
+1. **Posture + ground rules** — head/hand split; "you seeded the kernel; I implemented; treat bundled
+   sources as authoritative; cite `path:line`."
+2. **What was built** — the phases/PRs shipped, in one scannable pass, mapped to the kernel's roadmap.
+3. **Bundle manifest** — every file with a one-line "why it's here."
+4. **The drift catalog** — each deviation from the kernel with your disposition (faithful / deliberate—
+   here's the rationale / fixed-this-round). This is the core of a fidelity round.
+5. **Fidelity questions** — ask the head to confirm the build is faithful and to **bless or redirect
+   each deliberate deviation** (especially axis/sequencing calls).
+6. **Next-phase planning** — present the open sequencing decision (e.g. MLB feature-completeness vs.
+   running-app orchestration vs. league expansion) and ask the head to sequence it.
+7. **What do *you* need from us?** — ask the head to list its own unknowns / files it wants next round.
+8. **Response format** — overall fidelity read; per-deviation verdict (bless/redirect); next-phase plan
+   with sequencing; severity-tagged findings (Critical/High/Medium/Low/Nit); its own open questions.
+
+**Round 2+ — convergence.** What changed since last round; **report your in-code verification of the
+head's claims back to it**; answer its prior questions; then a tight set of sign-off questions.
+
+---
+
+## 5. Adjudication (the REVIEWS "Decisions" block)
+
+After pasting the verbatim verdict, work every finding:
+
+- **Per finding:** `**<title> (severity):** <restatement> → **Decision:** accepted / deferred / disagreed because …`
+- **Re-verify load-bearing claims in-code first** — a severity can move once you read the cited code
+  (confirmed → fold the fix; resolved → already handled; downgraded/refuted → cite contradicting code).
+- **Capture the head's open questions** as a table with dispositions (answer-in-code / next-round / decided).
+- **Record user decisions** made mid-cadence in REVIEWS *and* fold them into the plan + STATUS.
+
+---
+
+## 6. Closure & after
+
+- **Converge** on a clean "Proceed" with no open framing questions — don't manufacture rounds.
+- **One framing question left?** Close it with a short followup in the same round, not a fresh cycle.
+- **After convergence:** fold the head's next-phase plan into STATUS → Next, then implement per the
+  normal per-PR + QC workflow. When a step both de-risks *and* generates data a later round wanted,
+  prefer it first.
+
+---
+
+## 7. The kernel-diff method (omni-specific)
+
+The frozen baseline is `docs/agent_context/kernel/`. To catalog drift each round:
+
+```bash
+K=docs/agent_context/kernel
+diff "$K/AGENTS.md" AGENTS.md
+for f in ARCHITECTURE_TYPED_DOMAIN.md ROADMAP.md BACKLOG.yaml SOURCES.md; do diff "$K/$f" "docs/agent_context/$f"; done
+# structure drift: compare the proposed layout to as-built
+diff <(sed -n '/```text/,/```/p' "$K/ARCHITECTURE_TYPED_DOMAIN.md") <(find omni -name '*.py' | sort)
+```
+
+Classify each diff: **benign enrichment** (docs grew consistently), **deliberate deviation** (defend
+it to the head), or **accidental drift** (fix it yourself). Doc-vs-reality mismatches (a doc citing
+modules that don't exist) are accidental — fix before the round.
+
+---
+
+## 8. Memory linkage
+
+Keep a `project_omni_review.md` auto-memory pointing at the trio, the current round, and the hard-won
+reframings, so the cadence survives across sessions. Add a one-line pointer in `MEMORY.md`.

--- a/.claude/skills/external-review/templates.md
+++ b/.claude/skills/external-review/templates.md
@@ -1,0 +1,131 @@
+# External-review cadence — templates
+
+Copy-paste skeletons for the [external-review](SKILL.md) skill. Replace `<…>`. Conventions in [reference.md](reference.md).
+
+---
+
+## A. Main brief — `~/.claude/plans/omni-<slug>.md`
+
+```markdown
+# Omni external review — <slug> (round N)
+
+> **Posture:** head (flagship/CGPT) plans · hand (Claude Code) implements + self-reviews.
+> **Status:** <round-N pending | reviewed → verdict | converged>. Baseline: `docs/agent_context/kernel/` (frozen <date>).
+
+## What was built (vs. the kernel roadmap)
+<scannable: phases/PRs shipped, mapped to the kernel's roadmap order>
+
+## Drift catalog (summary — full table in SUPPLEMENT)
+| # | Kernel item | As-built | Class | Disposition |
+|---|---|---|---|---|
+| 1 | <…> | <…> | faithful / deliberate / accidental | fixed this round / defend / for the head |
+
+## Scope calibration (current-ship vs deferred)
+| Item | Disposition |
+|---|---|
+| <…> | **Current ship** / **Deferred** / **Open — round N** |
+
+## Questions for the head (round N)
+1. Fidelity: <…>
+2. Bless or redirect: <deviation>
+3. Sequence the next phase: <options>
+
+## Next-phase options (for the head to sequence)
+- <option A — e.g. MLB feature-completeness (M3)>
+- <option B — running-app orchestration loop>
+- <option C — league expansion (M6 NFL)>
+```
+
+---
+
+## B. SUPPLEMENT — `~/.claude/plans/omni-<slug>-SUPPLEMENT.md`
+
+```markdown
+# Omni external review — <slug> — SUPPLEMENT
+
+Companion to `omni-<slug>.md`. Citations: **[verified]** = read this session; **[reported]** = secondhand.
+
+## 1. Full drift table
+| # | Kernel (file) | Plan said | As-built (`file:line`) | Verdict + rationale |
+
+## 2. In-code fidelity verifications
+1. <claim, e.g. "no raw JSON outside providers/"> — CONFIRMED/REFUTED — <evidence, file:line>
+
+## 3. Test / quality snapshot
+<pytest summary · mypy/black · omni coverage (--cov-branch)>
+
+## 4. Touchpoint map for the next phase
+<file:line for where the next work would land>
+```
+
+---
+
+## C. REVIEWS — `~/.claude/plans/omni-<slug>-REVIEWS.md`
+
+```markdown
+# Omni external review — <slug> — rounds
+
+Per-round log. Bundles at `~/scratchpad/omni-scoreboard/round-N.zip`.
+
+## Round N — [pending | date]
+**Bundle:** `round-N.zip`  **Briefing:** `round-N-prompt.md`
+
+### Briefing summary
+<what we sent + focus questions>
+
+### Verdict (verbatim archived in `round-N-verdict.md`)
+<overall read + key extracts>
+
+### Decisions (our adjudication)
+- **<finding> (severity):** <restatement> → **Decision:** accepted / deferred / disagreed because …
+
+### Our in-code verification of the head's claims
+1. <claim> — CONFIRMED / RESOLVED / DOWNGRADED — `file:line` + rationale
+
+### Head's open questions + disposition
+| # | Question | Disposition (answer-in-code / next-round / decided) |
+
+## Convergence checklist
+Stops when: clean "Proceed" + no open framing questions + all accepted findings landed.
+```
+
+---
+
+## D. Round-N briefing — `~/scratchpad/omni-scoreboard/round-N-prompt.md`
+
+```markdown
+# Omni Scoreboard — external review, round N (<fidelity + plan | converge>)
+
+You are the **planning head** for Omni Scoreboard, a typed rebuild of MLB-LED-Scoreboard into an
+`omni/` package (friends-and-family LED sports scoreboard; three panel profiles). You seeded this
+project's kernel (bundled, frozen); I (Claude Code) am the **implementing hand**. Treat bundled
+sources as authoritative; cite `path:line`. <Prior verdict at round-(N-1)-verdict.md.>
+
+## 1. What I built (vs. your kernel roadmap)
+<the phases/PRs, mapped to the roadmap order>
+
+## 2. What's in the bundle
+```
+plans/    <trio>
+sources/  kernel/ (frozen) · AGENTS.md · STATUS.md · ARCHITECTURE (as-built) · omni-tree.txt · <key modules> · test-snapshot.md
+```
+
+## 3. Drift catalog (my self-review)
+<each deviation: kernel said → as-built → my disposition (faithful / deliberate+rationale / fixed)>
+
+## 4. Fidelity questions
+<ask: is the build faithful? bless or redirect each deliberate deviation?>
+
+## 5. Next-phase planning
+<the open sequencing decision + options; ask the head to sequence and scope current-ship vs deferred>
+
+## 6. What do you need from me next round?
+<ask the head to list its own unknowns / files it wants>
+
+## 7. Response format
+- Overall fidelity read • per-deviation verdict (bless/redirect) • next-phase plan + sequencing •
+  severity-tagged findings (Critical/High/Medium/Low/Nit) • your own open questions
+
+<Round 2+: replace 3–6 with "What changed", "My in-code verification of your claims (reported back)",
+"Answers to your prior questions", and tight sign-off focus questions.>
+```

--- a/docs/agent_context/kernel/.cursor/rules/omni-scoreboard.mdc
+++ b/docs/agent_context/kernel/.cursor/rules/omni-scoreboard.mdc
@@ -1,0 +1,40 @@
+---
+description: Omni Scoreboard project rules
+globs:
+  - "**/*.py"
+  - "**/*.md"
+  - "**/*.json"
+  - "**/*.yaml"
+alwaysApply: true
+---
+
+# Omni Scoreboard Cursor Rules
+
+This project is a friends-and-family LED sports scoreboard, not a consumer SaaS product.
+
+Support these display profiles equally:
+
+- `single_64x32`
+- `stack_64x64`
+- `quad_128x64`
+
+Typed/OOP policy:
+
+- Prefer strict typed objects over primitives in domain code.
+- Use `League`, `Team`/`BaseballTeam`, `PanelProfile`, sport-specific event enums, `DisplayTiming`, `CardPriority`, and typed card payloads.
+- Raw strings/dicts are acceptable only at API/config/fixture boundaries.
+- Provider modules convert raw API JSON into typed domain objects immediately.
+- Renderers consume typed `ScoreboardCard` payloads and never fetch data.
+
+Roadmap order:
+
+1. Clean upstream-based repo.
+2. Emulator and fixture replay.
+3. Typed domain core.
+4. Three display profiles.
+5. MLB polish and bug fixes.
+6. Generic TV-delay/interleaved card queue.
+7. Local setup/updater/device management.
+8. NFL, NBA, NHL, PGA, NCAA later.
+
+Do not add `v2` to repo/branch/product names unless it is a throwaway local branch.

--- a/docs/agent_context/kernel/AGENTS.md
+++ b/docs/agent_context/kernel/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — Omni Scoreboard
+
+Read this first before changing code.
+
+## Project intent
+
+Omni Scoreboard is a friends-and-family LED sports scoreboard. It is not a full consumer SaaS/product company.
+
+Prioritize reliability, local setup, typed code, fixture replay, and delightful small-display behavior over feature sprawl.
+
+## Supported displays
+
+All significant UI work must consider these three profiles equally:
+
+- `single_64x32`: 1x1 64x32 panel.
+- `stack_64x64`: 2x1 vertical stack of two 64x32 panels, logical 64x64.
+- `quad_128x64`: 2x2 matrix, logical 128x64.
+
+A feature may compromise by profile, but the compromise must be explicit and tested.
+
+## Repo posture
+
+The revived repo should use `omni-scoreboard`, not `omni-scoreboard-v2` or similar.
+
+The old fork should be preserved as `omni-scoreboard-legacy`. The new repo should be based on current upstream `MLB-LED-Scoreboard/mlb-led-scoreboard`, with old Omni work ported selectively.
+
+Do not blindly merge the legacy fork into upstream. Use legacy code as reference/prototype material.
+
+## Immediate priorities
+
+1. Stand up clean repo/local clone.
+2. Run upstream in emulator.
+3. Add typed enum/domain foundation.
+4. Add display profile model for 64x32, 64x64, 128x64.
+5. Add fixture replay and snapshot tests.
+6. Fix MLB P0/P1 bugs before broad league expansion.
+7. Implement generic delay/event/card queue.
+8. Add setup portal, safe updater, sleep schedule, and physical button support.
+9. Add NFL, NBA, NHL, PGA, then NCAA later.
+
+## Type policy
+
+Do not introduce new raw stringly-typed league/team/event/card concepts.
+
+Use typed enums and frozen/slotted dataclasses:
+
+- `League`, not `"mlb"`.
+- `BaseballTeam`, not `"COL"`.
+- `BaseballGameEventType.HOME_RUN`, not `"home_run"`.
+- `PanelProfile.SINGLE_64X32`, not `(64, 32)`.
+- `DisplayTiming`, not loose `available_at`, `expires_at`, `min_seconds`, `max_seconds` primitives scattered across code.
+
+Raw JSON may exist only in provider boundary modules and fixtures.
+
+## Rendering policy
+
+Renderers should consume typed `ScoreboardCard` payloads and a `PanelProfile`. They should not fetch data. They should not parse provider JSON. They should not own TV-delay semantics.
+
+Every spacing/animation bug fixed should get a fixture or golden-image snapshot test.
+
+## Data policy
+
+Free/low-cost by default:
+
+- MLB: upstream MLB StatsAPI integration.
+- NFL/NBA/NHL/PGA initial spike: ESPN site APIs, isolated behind provider interfaces.
+- PGA probability/cut-line optional: DataGolf if worth the key/cost.
+- Commercial fallback only after free sources fail product needs.
+
+## Device policy
+
+For friends/family units:
+
+- Local Wi-Fi setup portal, not mobile app.
+- Safe `systemd` updater with rollback, not cron `git pull`.
+- Local config and credentials.
+- Sleep/wake schedule.
+- Physical switch/button support.
+- Avoid cloud dependencies.
+
+## Never do these without explicit human approval
+
+- Delete or force-push legacy branches.
+- Rewrite published history on `main`.
+- Add paid data/API dependency as required default.
+- Add user accounts/cloud backend.
+- Drop support for any of the three display profiles.
+- Commit secrets, Wi-Fi credentials, or API keys.

--- a/docs/agent_context/kernel/ARCHITECTURE_TYPED_DOMAIN.md
+++ b/docs/agent_context/kernel/ARCHITECTURE_TYPED_DOMAIN.md
@@ -1,0 +1,588 @@
+# Omni Scoreboard Typed Domain Architecture
+
+## Guiding principle
+
+Raw primitives belong at the boundaries only: config JSON, provider JSON, CLI args, and file paths. Inside the application, domain concepts should be typed objects that own their own concerns.
+
+Examples:
+
+- Do not pass `"mlb"`; pass `League.MLB`.
+- Do not pass `"COL"`; pass a `BaseballTeam` or `TeamId` resolved by the registry.
+- Do not pass `"home_run"`; pass `BaseballGameEventType.HOME_RUN`.
+- Do not pass `(64, 32)`; pass `DisplayProfile.SINGLE_64X32` or a `PanelGeometry` object.
+- Do not pass loose priority floats everywhere; pass `DisplayPriority`/`PriorityScore` with reason codes.
+
+## Enum policy
+
+Crib the uploaded enum approach in spirit and implementation:
+
+- `StrEnumMixin` for string-valued identifiers where the value is canonical and JSON-safe.
+- `IntEnumMixin` for ordered severities/urgencies/priorities where comparison is meaningful.
+- `try_coerce_enum()` for tolerant fixture/replay/config readers.
+- Strict construction paths should fail fast; tolerant paths should only be used for debugging/replay/migration.
+
+Recommended initial enum module: `omni/core/enum.py`.
+
+## Package layout
+
+```text
+omni/
+  core/
+    enum.py
+    ids.py
+    time.py
+    colors.py
+    serialization.py
+  domain/
+    base.py
+    teams.py
+    athletes.py
+    baseball.py
+    football.py
+    basketball.py
+    hockey.py
+    golf.py
+  events/
+    base.py
+    baseball.py
+    football.py
+    basketball.py
+    hockey.py
+    golf.py
+  cards/
+    base.py
+    baseball.py
+    football.py
+    basketball.py
+    hockey.py
+    golf.py
+  queue/
+    delay_buffer.py
+    priority.py
+    scheduler.py
+  panels/
+    profiles.py
+    geometry.py
+    layout_contract.py
+  providers/
+    base.py
+    mlb_statsapi.py
+    espn.py
+    datagolf.py
+    sportsdataio.py
+  renderers/
+    base.py
+    profile_single_64x32.py
+    profile_stack_64x64.py
+    profile_quad_128x64.py
+  preview/
+    fixture_replay.py
+    snapshot.py
+    web.py
+```
+
+This can be introduced incrementally inside the upstream tree. Do not attempt a giant rewrite before the emulator works.
+
+## Core enums
+
+```python
+from enum import Enum, IntEnum
+from omni.core.enum import StrEnumMixin, IntEnumMixin
+
+class Sport(StrEnumMixin, str, Enum):
+    BASEBALL = "baseball"
+    FOOTBALL = "football"
+    BASKETBALL = "basketball"
+    HOCKEY = "hockey"
+    GOLF = "golf"
+
+class League(StrEnumMixin, str, Enum):
+    MLB = "mlb"
+    NFL = "nfl"
+    NBA = "nba"
+    NHL = "nhl"
+    PGA = "pga"
+    NCAAF = "ncaaf"
+    NCAAB = "ncaab"
+
+    @property
+    def sport(self) -> Sport:
+        return {
+            League.MLB: Sport.BASEBALL,
+            League.NFL: Sport.FOOTBALL,
+            League.NBA: Sport.BASKETBALL,
+            League.NHL: Sport.HOCKEY,
+            League.PGA: Sport.GOLF,
+            League.NCAAF: Sport.FOOTBALL,
+            League.NCAAB: Sport.BASKETBALL,
+        }[self]
+
+class PanelProfile(StrEnumMixin, str, Enum):
+    SINGLE_64X32 = "single_64x32"
+    STACK_64X64 = "stack_64x64"
+    QUAD_128X64 = "quad_128x64"
+
+class GameStatus(StrEnumMixin, str, Enum):
+    SCHEDULED = "scheduled"
+    PREGAME = "pregame"
+    LIVE = "live"
+    DELAYED = "delayed"
+    SUSPENDED = "suspended"
+    FINAL = "final"
+    POSTPONED = "postponed"
+    CANCELED = "canceled"
+    UNKNOWN = "unknown"
+
+class DisplayPriority(IntEnumMixin, IntEnum):
+    BACKGROUND = 0
+    NORMAL = 10
+    FAVORITE = 20
+    HIGH_LEVERAGE = 30
+    ALERT = 40
+    STICKY = 50
+
+class UpdateUrgency(IntEnumMixin, IntEnum):
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    LIVE_CRITICAL = 3
+```
+
+## Event type enums
+
+Keep event type enums sport-specific. A baseball event and a football event may both be “score”, but the downstream concerns are different.
+
+```python
+class BaseballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    PITCH = "pitch"
+    BALL = "ball"
+    CALLED_STRIKE = "called_strike"
+    SWINGING_STRIKE = "swinging_strike"
+    FOUL = "foul"
+    BALL_IN_PLAY = "ball_in_play"
+    STRIKEOUT_LOOKING = "strikeout_looking"
+    STRIKEOUT_SWINGING = "strikeout_swinging"
+    WALK = "walk"
+    HIT_BY_PITCH = "hit_by_pitch"
+    SINGLE = "single"
+    DOUBLE = "double"
+    TRIPLE = "triple"
+    HOME_RUN = "home_run"
+    SAC_FLY = "sac_fly"
+    SAC_BUNT = "sac_bunt"
+    DOUBLE_PLAY = "double_play"
+    TRIPLE_PLAY = "triple_play"
+    RUN_SCORED = "run_scored"
+    RBI = "rbi"
+    PITCHING_CHANGE = "pitching_change"
+    CHALLENGE = "challenge"
+    ABS_CHALLENGE = "abs_challenge"
+    INNING_START = "inning_start"
+    HALF_INNING_END = "half_inning_end"
+    GAME_FINAL = "game_final"
+    NO_HITTER_ACTIVE = "no_hitter_active"
+    NO_HITTER_BROKEN = "no_hitter_broken"
+    PERFECT_GAME_ACTIVE = "perfect_game_active"
+    PERFECT_GAME_BROKEN = "perfect_game_broken"
+```
+
+NFL/NBA/NHL/PGA should get parallel sport-specific enums, not a giant universal enum.
+
+## Value object policy
+
+Use frozen, slotted dataclasses for durable domain values.
+
+```python
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from typing import Final
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    name: str              # e.g. "mlb_statsapi", "espn", "datagolf"
+    raw_url: str | None = None
+
+@dataclass(frozen=True, slots=True)
+class LeagueScopedId:
+    league: League
+    source: SourceRef
+    raw: str
+
+    def __str__(self) -> str:
+        return f"{self.league}:{self.source.name}:{self.raw}"
+
+@dataclass(frozen=True, slots=True)
+class DurationSeconds:
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError("duration cannot be negative")
+
+    def as_timedelta(self) -> timedelta:
+        return timedelta(seconds=self.value)
+
+@dataclass(frozen=True, slots=True)
+class RGBColor:
+    r: int
+    g: int
+    b: int
+
+    def __post_init__(self) -> None:
+        for component in (self.r, self.g, self.b):
+            if not 0 <= component <= 255:
+                raise ValueError("RGB components must be 0..255")
+
+    def relative_luminance(self) -> float:
+        def convert(channel: int) -> float:
+            c = channel / 255
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+        return 0.2126 * convert(self.r) + 0.7152 * convert(self.g) + 0.0722 * convert(self.b)
+
+    def contrast_ratio(self, other: "RGBColor") -> float:
+        lighter = max(self.relative_luminance(), other.relative_luminance())
+        darker = min(self.relative_luminance(), other.relative_luminance())
+        return (lighter + 0.05) / (darker + 0.05)
+```
+
+Use `typing.NewType` only for very small internal distinctions. Prefer real value objects when behavior/validation/serialization is needed.
+
+## Competitors: teams and golfers
+
+Golf means not every league has teams. Model the more general concept first.
+
+```python
+from dataclasses import dataclass
+from typing import Protocol
+
+class Competitor(Protocol):
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+
+@dataclass(frozen=True, slots=True)
+class Team:
+    id: LeagueScopedId
+    league: League
+    display_name: str
+    short_name: str
+    abbreviation: str
+    primary_color: RGBColor
+    secondary_color: RGBColor
+    logo: "LogoAsset"
+
+    def best_text_color_on_primary(self) -> RGBColor:
+        white = RGBColor(255, 255, 255)
+        black = RGBColor(0, 0, 0)
+        return white if white.contrast_ratio(self.primary_color) >= black.contrast_ratio(self.primary_color) else black
+
+@dataclass(frozen=True, slots=True)
+class BaseballTeam(Team):
+    division: str | None = None
+    league_side: str | None = None  # AL/NL, intentionally typed later if desired
+
+@dataclass(frozen=True, slots=True)
+class Golfer:
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+    country: str | None = None
+```
+
+A provider should resolve raw team/player IDs through a registry and return these objects. Renderers should not know ESPN/MLB raw IDs.
+
+## Contest model
+
+Use `Contest` instead of assuming team-vs-team `Game` everywhere.
+
+```python
+@dataclass(frozen=True, slots=True)
+class Contest:
+    id: LeagueScopedId
+    league: League
+    status: GameStatus
+    scheduled_start: datetime
+    competitors: tuple[Competitor, ...]
+    venue_name: str | None = None
+
+    @property
+    def sport(self) -> Sport:
+        return self.league.sport
+
+@dataclass(frozen=True, slots=True)
+class TeamGame(Contest):
+    away: Team
+    home: Team
+
+    def __post_init__(self) -> None:
+        if self.away == self.home:
+            raise ValueError("home and away teams must differ")
+
+@dataclass(frozen=True, slots=True)
+class GolfTournament(Contest):
+    tournament_name: str = ""
+    round_number: int | None = None
+    cut_line: int | None = None
+```
+
+## GameEvent redesign
+
+Generic event base:
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Generic, TypeVar
+
+EventTypeT = TypeVar("EventTypeT", bound=Enum)
+PayloadT = TypeVar("PayloadT")
+
+@dataclass(frozen=True, slots=True)
+class EventImportance:
+    priority: DisplayPriority
+    urgency: UpdateUrgency
+    leverage: float
+    rarity: float
+    favorite_relevance: float
+    reasons: tuple[str, ...] = ()
+
+    def combined_score(self) -> float:
+        return (
+            int(self.priority)
+            + int(self.urgency) * 5
+            + self.leverage * 20
+            + self.rarity * 15
+            + self.favorite_relevance * 20
+        )
+
+@dataclass(frozen=True, slots=True)
+class GameEvent(Generic[EventTypeT, PayloadT]):
+    id: LeagueScopedId
+    contest: Contest
+    event_type: EventTypeT
+    source: SourceRef
+    source_time: datetime
+    observed_at: datetime
+    competitors: tuple[Competitor, ...]
+    importance: EventImportance
+    payload: PayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league
+```
+
+Baseball specialization:
+
+```python
+@dataclass(frozen=True, slots=True)
+class BaseballCount:
+    balls: int
+    strikes: int
+    outs: int
+
+@dataclass(frozen=True, slots=True)
+class BaseballBaseState:
+    first: BaseballTeam | None = None  # replace with Runner once modeled
+    second: BaseballTeam | None = None
+    third: BaseballTeam | None = None
+
+@dataclass(frozen=True, slots=True)
+class BaseballPlayPayload:
+    inning: int
+    half: str  # later: HalfInning enum
+    count: BaseballCount | None
+    description: str
+    rbi: int = 0
+    pitch_type: str | None = None
+    fielder_sequence: tuple[int, ...] = ()
+
+@dataclass(frozen=True, slots=True)
+class BaseballGameEvent(GameEvent[BaseballGameEventType, BaseballPlayPayload]):
+    pass
+```
+
+Important: `fielder_sequence` is structured as `tuple[int, ...]`, not a string like `"9-6-4-"`. Rendering converts it to a string late and can avoid truncating dangling delimiters.
+
+## ScoreboardCard redesign
+
+`ScoreboardCard` should be a renderable domain object, not a loose payload bag.
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Generic, TypeVar
+
+CardPayloadT = TypeVar("CardPayloadT")
+
+@dataclass(frozen=True, slots=True)
+class CardId:
+    raw: str
+
+@dataclass(frozen=True, slots=True)
+class DedupeKey:
+    raw: str
+
+@dataclass(frozen=True, slots=True)
+class DisplayTiming:
+    available_at: datetime
+    expires_at: datetime | None
+    min_display: DurationSeconds
+    max_display: DurationSeconds
+
+    def is_available(self, now: datetime) -> bool:
+        return now >= self.available_at and (self.expires_at is None or now < self.expires_at)
+
+@dataclass(frozen=True, slots=True)
+class LayoutSupport:
+    profiles: frozenset[PanelProfile]
+    fallback_card_kind: str | None = None
+    compromise_notes: tuple[str, ...] = ()
+
+    def supports(self, profile: PanelProfile) -> bool:
+        return profile in self.profiles
+
+@dataclass(frozen=True, slots=True)
+class CardPriority:
+    band: DisplayPriority
+    score: float
+    reasons: tuple[str, ...]
+
+@dataclass(frozen=True, slots=True)
+class ScoreboardCard(Generic[CardPayloadT]):
+    id: CardId
+    kind: "CardKind"
+    contest: Contest
+    source_event_ids: tuple[LeagueScopedId, ...]
+    timing: DisplayTiming
+    priority: CardPriority
+    layout_support: LayoutSupport
+    dedupe_key: DedupeKey
+    payload: CardPayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league
+```
+
+## Card payload examples
+
+```python
+@dataclass(frozen=True, slots=True)
+class LiveBaseballCardPayload:
+    score: "ScoreState"
+    count: BaseballCount
+    base_state: BaseballBaseState
+    inning: int
+    half: str
+    batter_name: str | None
+    pitcher_name: str | None
+    last_play: str | None
+    no_hitter_badge: bool = False
+
+@dataclass(frozen=True, slots=True)
+class GolfLeaderboardCardPayload:
+    tournament: GolfTournament
+    leaders: tuple["GolfLeaderboardRow", ...]
+    favorite_rows: tuple["GolfLeaderboardRow", ...]
+    cut_line: int | None
+```
+
+## Provider boundaries
+
+Provider modules own raw API shape. The rest of the system never sees raw JSON.
+
+```python
+class Provider(Protocol):
+    source: SourceRef
+    league: League
+
+    def refresh(self) -> "ProviderUpdate": ...
+```
+
+Provider update should contain typed domain objects:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProviderUpdate:
+    source: SourceRef
+    observed_at: datetime
+    contests: tuple[Contest, ...]
+    events: tuple[GameEvent, ...]
+    warnings: tuple[str, ...] = ()
+```
+
+## Queue responsibilities
+
+- `DelayBuffer`: owns TV-delay semantics.
+- `PriorityScorer`: converts events/domain states into `CardPriority`.
+- `CardFactory`: converts events into typed card payloads.
+- `InterleavedCardQueue`: picks the next eligible card with fairness across leagues/contests.
+
+Do not put delay logic in renderers.
+Do not put provider polling logic in card classes.
+Do not let one league's provider starve the display.
+
+## Rendering contract
+
+```python
+class Renderer(Protocol[CardPayloadT]):
+    supported_profiles: frozenset[PanelProfile]
+
+    def render(
+        self,
+        card: ScoreboardCard[CardPayloadT],
+        profile: PanelProfile,
+        canvas: "Canvas",
+    ) -> None: ...
+```
+
+Renderers are pure-ish: given a card, profile, and frame time, they draw a frame. They should not fetch data.
+
+## Type-checking and code-quality policy
+
+Start with incremental strictness rather than boiling the ocean.
+
+Recommended practices:
+
+- `from __future__ import annotations` in all new files.
+- `@dataclass(frozen=True, slots=True)` for value/domain objects unless mutation is intentional.
+- `Protocol` for provider/renderer interfaces.
+- `typing.override` where Python version supports it, or `typing_extensions.override`.
+- `assert_never` for exhaustive enum matching where practical.
+- `Final` for constants.
+- No `Any` in domain code without a comment explaining the boundary.
+- No raw API JSON beyond `providers/*`.
+- No renderer dependency on ESPN/MLB/StatsAPI field names.
+- Keep serialization explicit: enums use `to_json_value()`.
+- Use pytest fixture replay and golden-image snapshot tests.
+
+Potential toolchain:
+
+- `mypy` or `pyright` for new `omni/*` modules.
+- `ruff` for linting and formatting if introduced carefully.
+- `pytest` for fixtures and snapshots.
+- Avoid Pydantic as a runtime dependency until Pi performance and packaging are checked. Pydantic is attractive for config/provider boundaries, but dataclasses plus explicit parser functions may be enough.
+
+## Migration strategy
+
+1. Add typed modules alongside upstream code.
+2. Wrap existing upstream game data into typed objects without changing rendering.
+3. Add typed cards for one MLB card.
+4. Add renderer contract for that card across all three profiles.
+5. Expand card-by-card.
+6. Only then generalize for NFL/NBA/NHL/PGA.
+
+## Anti-patterns to avoid
+
+- Giant universal `GameEventType` enum covering all sports.
+- Dict payloads that leak everywhere.
+- Event priorities as unexplained floats.
+- Hard-coded team strings in renderers.
+- Cropping 128x64 cards down to 64x32.
+- TV-delay implemented separately per sport.
+- `git pull` cron with no rollback.
+- Paid data as a default dependency.

--- a/docs/agent_context/kernel/BACKLOG.yaml
+++ b/docs/agent_context/kernel/BACKLOG.yaml
@@ -1,0 +1,270 @@
+project: omni-scoreboard
+updated: "2026-06-14"
+principles:
+  - friends_and_family_scope
+  - no_consumer_saas
+  - equal_display_profile_support
+  - typed_domain_objects_over_primitives
+  - free_low_cost_data_by_default
+  - fixture_replay_before_visual_polish
+
+display_profiles:
+  - id: single_64x32
+    physical: "1x1 64x32 panel"
+    logical_width: 64
+    logical_height: 32
+    role: "primary compact family unit"
+  - id: stack_64x64
+    physical: "2x1 vertical stack of 64x32 panels or native equivalent"
+    logical_width: 64
+    logical_height: 64
+    role: "balanced rich compact layout"
+  - id: quad_128x64
+    physical: "2x2 matrix of 64x32 panels"
+    logical_width: 128
+    logical_height: 64
+    role: "legacy/rich dashboard"
+
+milestones:
+  - id: M0
+    name: repo_reset_local_foundation
+    goal: "New omni-scoreboard repo from current upstream; legacy preserved; emulator running."
+    tasks:
+      - id: M0-001
+        title: "Rename old fork to omni-scoreboard-legacy"
+        labels: [repo, github, p0]
+        acceptance:
+          - "ajszoke/omni-scoreboard no longer points to the legacy repo"
+          - "legacy repo remains accessible as omni-scoreboard-legacy"
+          - "No old branches/tags are deleted"
+      - id: M0-002
+        title: "Create revived omni-scoreboard from upstream history"
+        labels: [repo, upstream, p0]
+        notes:
+          - "May need clone-and-push path because GitHub may not allow second personal fork of same upstream."
+        acceptance:
+          - "origin points to ajszoke/omni-scoreboard"
+          - "upstream points to MLB-LED-Scoreboard/mlb-led-scoreboard"
+          - "legacy points to ajszoke/omni-scoreboard-legacy"
+      - id: M0-003
+        title: "Install/run upstream emulator"
+        labels: [emulator, dev_env, p0]
+        acceptance:
+          - "Can launch emulated scoreboard locally"
+          - "Document exact command in README or docs/dev.md"
+
+  - id: M1
+    name: typed_domain_core
+    goal: "Typed OOP foundation for leagues, teams, contests, events, cards, display profiles."
+    tasks:
+      - id: M1-001
+        title: "Add enum mixins and base enums"
+        labels: [typing, architecture, p0]
+        acceptance:
+          - "StrEnumMixin and IntEnumMixin available under omni/core/enum.py"
+          - "League, Sport, PanelProfile, GameStatus, DisplayPriority, UpdateUrgency implemented"
+          - "Enum JSON serialization policy documented"
+      - id: M1-002
+        title: "Add typed IDs/value objects"
+        labels: [typing, architecture, p0]
+        acceptance:
+          - "LeagueScopedId, SourceRef, DurationSeconds, RGBColor, LogoAsset, PanelGeometry implemented"
+      - id: M1-003
+        title: "Add competitor/team/contest model"
+        labels: [typing, domain, p0]
+        acceptance:
+          - "Team, BaseballTeam, FootballTeam, BasketballTeam, HockeyTeam, Golfer, Contest, TeamGame, GolfTournament implemented"
+      - id: M1-004
+        title: "Add sport-specific event enums"
+        labels: [typing, events, p1]
+        acceptance:
+          - "BaseballGameEventType implemented first"
+          - "NFL/NBA/NHL/PGA placeholder enums exist or are planned"
+      - id: M1-005
+        title: "Redesign GameEvent and ScoreboardCard as typed generics"
+        labels: [typing, events, cards, p0]
+        acceptance:
+          - "GameEvent[event_type, payload] generic exists"
+          - "ScoreboardCard[payload] generic exists"
+          - "DisplayTiming, CardPriority, LayoutSupport, DedupeKey implemented"
+
+  - id: M2
+    name: display_profiles_preview_snapshots
+    goal: "All three display profiles are first-class and testable."
+    tasks:
+      - id: M2-001
+        title: "Implement DisplayProfile and PanelGeometry mapping"
+        labels: [display, panels, p0]
+      - id: M2-002
+        title: "Add renderer contract with profile support declaration"
+        labels: [rendering, typing, p0]
+      - id: M2-003
+        title: "Add fixture record/replay"
+        labels: [fixtures, dev_env, p0]
+      - id: M2-004
+        title: "Add emulator/browser preview"
+        labels: [preview, dev_env, p1]
+      - id: M2-005
+        title: "Add golden-image snapshot tests per display profile"
+        labels: [testing, rendering, p1]
+
+  - id: M3
+    name: mlb_excellence
+    goal: "MLB is polished across all three profiles."
+    tasks:
+      - id: M3-001
+        title: "Fix pregame card display halt"
+        labels: [mlb, bug, p0]
+      - id: M3-002
+        title: "Wrap sync delay into TV delay presets"
+        labels: [delay, config, mlb, p0]
+      - id: M3-003
+        title: "Fix logos/backgrounds/probability colors"
+        labels: [assets, color, mlb, p1]
+        notes: ["Pirates, Twins, White Sox, BAL probability contrast called out by user."]
+      - id: M3-004
+        title: "Reinstate color-clash alt logo background logic"
+        labels: [assets, color, rendering, p1]
+      - id: M3-005
+        title: "Map SWPR pitch type"
+        labels: [mlb, data, bug, p1]
+      - id: M3-006
+        title: "Stat line debounce and anchor stabilization"
+        labels: [rendering, mlb, p1]
+      - id: M3-007
+        title: "Fix bot-right cards spacing and fielder sequence truncation"
+        labels: [rendering, mlb, p1]
+      - id: M3-008
+        title: "Preserve last-K/play-of-inning card before inning transition"
+        labels: [mlb, queue, p2]
+      - id: M3-009
+        title: "No-hitter/perfect-game sticky priority"
+        labels: [mlb, priority, p2]
+      - id: M3-010
+        title: "Backwards K and K tracker"
+        labels: [mlb, rendering, p2]
+      - id: M3-011
+        title: "Challenge and ABS state tightening"
+        labels: [mlb, data, rendering, p2]
+      - id: M3-012
+        title: "End-of-game winner/loser logic and W/L/S tightening"
+        labels: [mlb, rendering, p2]
+      - id: M3-013
+        title: "Other-game/news ticker during idle/non-active states"
+        labels: [ticker, mlb, p2]
+      - id: M3-014
+        title: "Mid-inning linescore"
+        labels: [mlb, rendering, p3]
+      - id: M3-015
+        title: "K-zone with pitch blips"
+        labels: [mlb, rendering, p3]
+      - id: M3-016
+        title: "Pitching-change transition card"
+        labels: [mlb, animation, p3]
+      - id: M3-017
+        title: "HR stats/arcs experimental card"
+        labels: [mlb, fun, p4]
+
+  - id: M4
+    name: event_queue_delay_priority
+    goal: "Generic event/card engine for all leagues."
+    tasks:
+      - id: M4-001
+        title: "Implement DelayBuffer over source_time + tv delay"
+        labels: [queue, delay, p0]
+      - id: M4-002
+        title: "Implement PriorityScorer with reason codes"
+        labels: [queue, priority, p0]
+      - id: M4-003
+        title: "Implement InterleavedCardQueue fairness across contests/leagues"
+        labels: [queue, scheduler, p0]
+      - id: M4-004
+        title: "Add sticky alert semantics"
+        labels: [queue, priority, p1]
+      - id: M4-005
+        title: "Add priority-driven polling cadence"
+        labels: [providers, priority, p2]
+
+  - id: M5
+    name: family_device_experience
+    goal: "Local setup, safe updating, sleep/wake, physical switch."
+    tasks:
+      - id: M5-001
+        title: "First-boot Wi-Fi AP and local config portal"
+        labels: [setup, wifi, p0]
+      - id: M5-002
+        title: "Safe systemd updater with rollback"
+        labels: [updater, systemd, p0]
+      - id: M5-003
+        title: "Sleep/wake/night-dim schedule"
+        labels: [device, schedule, p1]
+      - id: M5-004
+        title: "GPIO physical switch/button support"
+        labels: [hardware, gpio, p1]
+      - id: M5-005
+        title: "1x1/2x1/2x2 case-design notes and BOM"
+        labels: [hardware, case, p2]
+
+  - id: M6
+    name: nfl_support
+    goal: "First non-MLB league."
+    tasks:
+      - id: M6-001
+        title: "ESPN NFL provider spike"
+        labels: [nfl, provider, p1]
+      - id: M6-002
+        title: "NFL domain/events/cards"
+        labels: [nfl, typing, rendering, p1]
+      - id: M6-003
+        title: "NFL red-zone/scoring/turnover priority"
+        labels: [nfl, priority, p2]
+
+  - id: M7
+    name: nba_support
+    goal: "NBA favorite-team support."
+    tasks:
+      - id: M7-001
+        title: "ESPN NBA provider spike"
+        labels: [nba, provider, p2]
+      - id: M7-002
+        title: "NBA live/final/clutch cards"
+        labels: [nba, rendering, p2]
+
+  - id: M8
+    name: nhl_support
+    goal: "NHL favorite-team support."
+    tasks:
+      - id: M8-001
+        title: "NHL provider spike"
+        labels: [nhl, provider, p2]
+      - id: M8-002
+        title: "NHL power-play/goal/final cards"
+        labels: [nhl, rendering, p2]
+
+  - id: M9
+    name: pga_support
+    goal: "PGA before NCAA."
+    tasks:
+      - id: M9-001
+        title: "ESPN PGA provider spike"
+        labels: [pga, provider, p2]
+      - id: M9-002
+        title: "Golf competitor/tournament/leaderboard model"
+        labels: [pga, typing, p2]
+      - id: M9-003
+        title: "Favorite golfer and leaderboard cards"
+        labels: [pga, rendering, p2]
+      - id: M9-004
+        title: "Cut-line/final-round priority model"
+        labels: [pga, priority, p3]
+      - id: M9-005
+        title: "Evaluate DataGolf for probability/cut-line enhancements"
+        labels: [pga, api, p3]
+
+  - id: M10
+    name: ncaa_later
+    goal: "NCAA after pro sports/PGA stability."
+    tasks:
+      - id: M10-001
+        title: "NCAAF/NCAAB provider and scope assessment"
+        labels: [ncaa, provider, p4]

--- a/docs/agent_context/kernel/CLAUDE_CODE_BOOTSTRAP_OPT.md
+++ b/docs/agent_context/kernel/CLAUDE_CODE_BOOTSTRAP_OPT.md
@@ -1,0 +1,255 @@
+# Claude Code Bootstrap Prompt — `/opt/omni-scoreboard`
+
+Paste this file into local Claude Code as the controlling prompt for standing up the revived project.
+
+## Mission
+
+Stand up the revived `omni-scoreboard` project locally at `/opt/omni-scoreboard` and on GitHub under `ajszoke/omni-scoreboard`, preserving the current legacy fork as `ajszoke/omni-scoreboard-legacy`.
+
+Do not use `v2` in the repo name.
+
+The revived project should be based on current `MLB-LED-Scoreboard/mlb-led-scoreboard` upstream history, with old Omni work ported selectively later.
+
+## Critical caveat: GitHub double-fork behavior
+
+Renaming `ajszoke/omni-scoreboard` to `omni-scoreboard-legacy` frees the name, but it may not allow creating a second GitHub-recognized fork of the same upstream under the same personal account. If GitHub refuses to create a second fork or `gh repo fork --fork-name omni-scoreboard` tries to rename/reuse the existing fork, do not fight it.
+
+Use one of these paths:
+
+### Path A — official GitHub fork metadata
+
+Use this only if the old fork is no longer owned by `ajszoke` as a fork of upstream, or has been deleted/detached/transferred elsewhere.
+
+### Path B — practical clone-and-push repo
+
+Create `ajszoke/omni-scoreboard` as a normal GitHub repo initialized from upstream history, with `upstream` remote configured. This preserves git history and supports future upstream pulls, but the GitHub UI will not show it as a fork. This is acceptable unless the human explicitly says GitHub fork metadata is required.
+
+## Safety rules
+
+- Do not delete any repo, branch, or tag.
+- Do not force-push `main`.
+- Do not commit secrets.
+- Stop and report if authenticated GitHub user is not `ajszoke` or does not have access.
+- Stop and report if `/opt/omni-scoreboard` already exists and is non-empty unless it is clearly the intended clone.
+- Use SSH remotes for `origin` if available; HTTPS is fine for `upstream`.
+
+## Step 1 — inspect local environment
+
+Run:
+
+```bash
+set -euo pipefail
+whoami
+hostname
+pwd
+uname -a
+git --version
+python3 --version || true
+gh --version || true
+gh auth status || true
+```
+
+If `gh` is missing or unauthenticated, ask the human to install/authenticate it before modifying GitHub.
+
+## Step 2 — inspect current GitHub repos
+
+Run:
+
+```bash
+gh repo view ajszoke/omni-scoreboard --json nameWithOwner,isFork,parent,defaultBranchRef,url || true
+gh repo view ajszoke/omni-scoreboard-legacy --json nameWithOwner,isFork,parent,defaultBranchRef,url || true
+gh repo view MLB-LED-Scoreboard/mlb-led-scoreboard --json nameWithOwner,defaultBranchRef,url,isFork || true
+```
+
+Expected initial state:
+
+- `ajszoke/omni-scoreboard` exists and is a fork of upstream.
+- `ajszoke/omni-scoreboard-legacy` probably does not exist yet.
+- Upstream default branch is likely `master`.
+
+## Step 3 — preserve/rename legacy repo
+
+If `ajszoke/omni-scoreboard` exists and `ajszoke/omni-scoreboard-legacy` does not exist, rename the old repo:
+
+```bash
+gh repo rename -R ajszoke/omni-scoreboard omni-scoreboard-legacy --yes
+```
+
+Verify:
+
+```bash
+gh repo view ajszoke/omni-scoreboard-legacy --json nameWithOwner,isFork,parent,defaultBranchRef,url
+```
+
+If `omni-scoreboard-legacy` already exists, do not overwrite it. Inspect and report.
+
+## Step 4 — create the revived repo
+
+First try Path A if it appears possible:
+
+```bash
+gh repo fork MLB-LED-Scoreboard/mlb-led-scoreboard   --fork-name omni-scoreboard   --default-branch-only   --clone=false
+```
+
+Then verify:
+
+```bash
+gh repo view ajszoke/omni-scoreboard --json nameWithOwner,isFork,parent,defaultBranchRef,url
+```
+
+If this fails because the account already has a fork, use Path B:
+
+```bash
+gh repo create ajszoke/omni-scoreboard   --public   --description "Friends-and-family omni sports LED scoreboard based on MLB-LED-Scoreboard"   --clone=false
+```
+
+## Step 5 — clone to `/opt/omni-scoreboard`
+
+Prepare `/opt` safely:
+
+```bash
+if [ -e /opt/omni-scoreboard ] && [ "$(ls -A /opt/omni-scoreboard 2>/dev/null | wc -l)" -ne 0 ]; then
+  echo "/opt/omni-scoreboard already exists and is non-empty; inspect before continuing" >&2
+  exit 1
+fi
+sudo mkdir -p /opt
+sudo chown "$USER":"$USER" /opt
+```
+
+If Path A succeeded:
+
+```bash
+git clone git@github.com:ajszoke/omni-scoreboard.git /opt/omni-scoreboard
+cd /opt/omni-scoreboard
+git remote add upstream https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git || true
+git remote add legacy https://github.com/ajszoke/omni-scoreboard-legacy.git || true
+git fetch --all --tags
+```
+
+If Path B is needed:
+
+```bash
+git clone https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git /opt/omni-scoreboard
+cd /opt/omni-scoreboard
+git remote rename origin upstream
+git remote add origin git@github.com:ajszoke/omni-scoreboard.git
+git remote add legacy https://github.com/ajszoke/omni-scoreboard-legacy.git || true
+git fetch --all --tags
+git push -u origin HEAD:main
+```
+
+If upstream default branch is `master`, decide whether local `main` should track a renamed branch or whether to keep `master`. Preferred for Omni is `main`, but preserve upstream tracking via the `upstream` remote.
+
+If current branch is `master` and we want `main`:
+
+```bash
+git branch -M main
+git push -u origin main
+```
+
+Set default branch in GitHub if needed:
+
+```bash
+gh repo edit ajszoke/omni-scoreboard --default-branch main || true
+```
+
+## Step 6 — add initial agent context
+
+Create directories:
+
+```bash
+mkdir -p docs/agent_context .cursor/rules starter_code
+```
+
+Copy the provided context artifacts into:
+
+```text
+docs/agent_context/ROADMAP.md
+docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md
+docs/agent_context/BACKLOG.yaml
+AGENTS.md
+.cursor/rules/omni-scoreboard.mdc
+starter_code/enum_core.py
+starter_code/domain_model_sketch.py
+```
+
+Commit them:
+
+```bash
+git checkout -b agent/bootstrap-context
+
+git add AGENTS.md .cursor/rules/omni-scoreboard.mdc docs/agent_context starter_code
+
+git commit -m "Add Omni Scoreboard agent context and typed architecture plan"
+git push -u origin agent/bootstrap-context
+```
+
+Create a PR if desired:
+
+```bash
+gh pr create   --repo ajszoke/omni-scoreboard   --base main   --head agent/bootstrap-context   --title "Add Omni Scoreboard roadmap and agent context"   --body "Adds roadmap, typed domain architecture, backlog, Cursor/agent rules, and bootstrap context for the revived Omni Scoreboard project."
+```
+
+If not using PRs yet, merge locally only after human approval.
+
+## Step 7 — install/run upstream emulator
+
+From `/opt/omni-scoreboard`, inspect upstream docs and do the least-invasive install first.
+
+Try:
+
+```bash
+cd /opt/omni-scoreboard
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip setuptools wheel
+```
+
+Then inspect install files before running anything with `sudo`:
+
+```bash
+ls -la
+sed -n '1,220p' install.sh || true
+sed -n '1,220p' README.md || true
+```
+
+If dependencies are clear, install for emulator/dev. Prefer venv-local installs before system installs.
+
+Try running emulator according to upstream current docs, likely one of:
+
+```bash
+./main.py --emulated
+python3 main.py --emulated
+```
+
+If missing dependencies, install only what is required and record commands in `docs/dev_setup.md`.
+
+## Step 8 — first implementation branch after bootstrap
+
+After context PR/commit exists, create the first real implementation branch:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b agent/typed-domain-foundation
+```
+
+Implement in small steps:
+
+1. Add `omni/core/enum.py` from `starter_code/enum_core.py`.
+2. Add tests for enum serialization and coercion.
+3. Add `League`, `Sport`, `PanelProfile`, `GameStatus`, `DisplayPriority`, `UpdateUrgency`.
+4. Add `LeagueScopedId`, `SourceRef`, `DurationSeconds`, `RGBColor`.
+5. Run tests/type checks.
+6. Commit.
+
+## Done criteria for this bootstrap
+
+Report back with:
+
+- GitHub repo URLs for legacy and revived repos.
+- Whether revived repo is an official GitHub fork or clone-and-push normal repo.
+- `/opt/omni-scoreboard` remotes.
+- Current branch and latest commit hash.
+- Emulator status and exact command used.
+- Any blockers, especially GitHub double-fork behavior, auth, DNS, or install failures.

--- a/docs/agent_context/kernel/PROVENANCE.md
+++ b/docs/agent_context/kernel/PROVENANCE.md
@@ -1,0 +1,37 @@
+# Kernel — frozen original context pack (provenance)
+
+This directory is the **verbatim, frozen** `omni_scoreboard_context_pack` that the external
+flagship model (ChatGPT, "CGPT" / "external") authored on **2026-06-14** to seed this project.
+It is the original specification the build was implemented against.
+
+**Do not edit these files.** They are the **drift-review baseline**: each external-review round
+diffs the as-built repo against this frozen plan to check the build stayed faithful. Editing them
+would destroy the baseline.
+
+## Posture (why this is housed here)
+
+This project runs a **head / hand** split (see the `external-review` skill in `.claude/skills/`):
+
+- **Head (planner):** the external flagship model. Owns conceptual reasoning, long-horizon
+  planning, and design review. It seeded this kernel and reviews each round's bundle.
+- **Hand (implementer):** Claude Code (this agent). Carries out the build, self-reviews against
+  this kernel, fixes drifts, and bundles each round for the head to review.
+
+## Living vs. frozen
+
+The **living** project docs supersede this kernel and are the day-to-day source of truth:
+
+- `AGENTS.md` (repo root) — the agent-agnostic map.
+- `docs/agent_context/STATUS.md` — current state.
+- `docs/agent_context/{ROADMAP,ARCHITECTURE_TYPED_DOMAIN,BACKLOG,SOURCES}.md` — evolved from
+  the same-named files here.
+
+When the living docs and this kernel disagree, that disagreement **is the drift** — surface it in
+the review round; don't silently reconcile by editing the kernel.
+
+## Contents
+
+The pack as delivered: `README.md` (pack overview), `CLAUDE_CODE_BOOTSTRAP_OPT.md` (the bootstrap
+prompt that stood up the repo), `AGENTS.md`, `ROADMAP.md`, `ARCHITECTURE_TYPED_DOMAIN.md`,
+`BACKLOG.yaml`, `SOURCES.md`, `.cursor/rules/omni-scoreboard.mdc`, and `starter_code/`
+(`enum_core.py`, `domain_model_sketch.py`).

--- a/docs/agent_context/kernel/README.md
+++ b/docs/agent_context/kernel/README.md
@@ -1,0 +1,30 @@
+# Omni Scoreboard Context Pack
+
+Purpose: provide durable, agent-ingestible context for reviving `omni-scoreboard` as a friends-and-family LED sports scoreboard project.
+
+Primary product scope:
+
+- Build small scoreboard boxes for friends and family.
+- Do not chase full consumer-grade competitor scope.
+- Equally support three display profiles:
+  - `single_64x32`: 1x1 64x32 panel.
+  - `stack_64x64`: 2x1 stack of two 64x32 panels, yielding 64x64.
+  - `quad_128x64`: 2x2 matrix of four 64x32 panels, yielding 128x64.
+- MLB remains the quality baseline.
+- Expansion order: MLB first, then NFL, NBA, NHL, PGA, then NCAA only after the above are stable.
+
+Files in this pack:
+
+- `ROADMAP.md` — comprehensive product and implementation roadmap.
+- `ARCHITECTURE_TYPED_DOMAIN.md` — typed/OOP architecture proposal and model sketches.
+- `BACKLOG.yaml` — issue-like structured backlog for agents.
+- `AGENTS.md` — repo-level agent orientation; drop at repository root.
+- `.cursor/rules/omni-scoreboard.mdc` — Cursor rule file; drop into `.cursor/rules/`.
+- `CLAUDE_CODE_BOOTSTRAP_OPT.md` — separate local Claude Code prompt for standing up GitHub and `/opt/omni-scoreboard`.
+- `starter_code/enum_core.py` — starter enum mixins and initial enums, cribbing the uploaded enum style.
+- `starter_code/domain_model_sketch.py` — typed domain/event/card sketch.
+- `SOURCES.md` — research basis and URLs.
+
+Important repository caveat:
+
+Renaming `ajszoke/omni-scoreboard` to `omni-scoreboard-legacy` frees the repository name, but it may not by itself permit creating a second personal GitHub fork of the same upstream. The bootstrap guide includes two paths: an official-fork path if the legacy fork is transferred/deleted/detached, and a practical clone-and-push path that preserves upstream history without GitHub fork metadata.

--- a/docs/agent_context/kernel/ROADMAP.md
+++ b/docs/agent_context/kernel/ROADMAP.md
@@ -1,0 +1,382 @@
+# Omni Scoreboard Roadmap
+
+## North star
+
+Omni Scoreboard is a tiny, opinionated sports-awareness appliance for friends and family.
+
+It should answer these questions at a glance:
+
+- Is my team playing?
+- What is the score?
+- Is anything important happening?
+- Did I miss a big play?
+- Is the game close?
+- Is there a no-hitter, red-zone drive, late comeback, cut-line sweat, or other high-leverage moment?
+- Can a non-Linux person plug it in, configure Wi-Fi, pick teams, and mostly forget it?
+
+Non-goals:
+
+- No full consumer SaaS.
+- No App Store app for initial setup.
+- No accounts unless absolutely necessary.
+- No paid data by default.
+- No fragile cron-based updater that can brick every family device at once.
+
+## Repository strategy
+
+### Facts
+
+- `ajszoke/omni-scoreboard` is currently a fork of `MLB-LED-Scoreboard/mlb-led-scoreboard`.
+- The legacy fork has 0 forks and 0 stars/watchers in the GitHub UI; renaming it has effectively no public blast radius.
+- Upstream is heavily diverged and active. The compare view shows upstream ahead by 809 commits and 177 files changed relative to the legacy fork comparison.
+- Upstream already supports board dimensions including 64x32, 64x64, and 128x64.
+- Upstream has useful modern foundation pieces: config schemas, plugin support, emulator mode, news/standings plugins, broadcast sync delay, API refresh configuration, Pi 5 work, frame pacing, and ABS indicator work.
+
+### Recommendation
+
+Use the name `omni-scoreboard` for the revived project, with no `v2` suffix.
+
+Preferred local/git shape:
+
+```text
+origin   -> git@github.com:ajszoke/omni-scoreboard.git
+upstream -> https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git
+legacy   -> https://github.com/ajszoke/omni-scoreboard-legacy.git
+```
+
+Because GitHub generally does not allow multiple forks of the same upstream under one owner, the new repo may need to be a normal repo created from an upstream clone rather than a GitHub-recognized fork. That is acceptable for this project as long as `upstream` remains configured and history is preserved.
+
+### Branching
+
+```text
+main          stable-ish human-usable branch
+agent/*       agent work branches
+feature/*     human-authored feature branches
+legacy/*      ported feature branches from old Omni commits
+upstream-sync temporary branch for upstream rebases/merge tests
+```
+
+Do not use `omni-v2` in branch or repo names unless it is a disposable local branch.
+
+## Supported displays: equal support, different compromises
+
+All meaningful features must declare behavior for each of these profiles.
+
+| Profile | Physical shape | Logical size | Product role | Design stance |
+|---|---:|---:|---|---|
+| `single_64x32` | 1x1 | 64x32 | Primary compact family unit | Sports pager: fewer, sharper cards |
+| `stack_64x64` | 2x1 vertical stack | 64x64 | New third supported layout | Rich single-game view; excellent for stat cards |
+| `quad_128x64` | 2x2 | 128x64 | Legacy/rich mode | Dense dashboard; animations and multi-region layouts |
+
+### Layout policy
+
+Every renderer must implement one of:
+
+1. Native support for all three profiles.
+2. Native support for one or two profiles plus an explicit, tested compromise for the others.
+3. A declaration that the card is not eligible for a profile, with a fallback card defined.
+
+Do not silently cram 128x64 content into 64x32.
+
+### Suggested display roles by profile
+
+| Feature | 64x32 | 64x64 | 128x64 |
+|---|---|---|---|
+| Live MLB at-bat | Score, inning, count, outs, bases | Add batter/pitcher and abbreviated play text | Full live dashboard |
+| Pregame | Matchup, start time, probable pitcher initials | Add probable pitcher names and odds/probability | Full pregame card with odds, weather, probable pitchers |
+| Probability bar | Thin, high contrast | Standard bar plus percentage | Full win-prob module with trend if available |
+| No-hitter/perfect game | Badge plus recurring full-screen alert | Sticky ribbon plus pitcher line | Dedicated panel region/sticky alert |
+| Last K / play-of-inning | Full-screen micro-card before inning card | Micro-card plus inning transition | Preserve in lower/right event queue |
+| K-zone | Maybe count-only; optional 3x3 blips | Simple zone/blips | Full pitch-location mini-map |
+| Other-game ticker | Idle states only | Idle states and lower ribbon | Persistent bottom ticker during non-active states |
+| Pitching change | Compact substitution card | Split outgoing/incoming stats | Full takeover animation |
+| HR arcs/3D | Defer/fallback text | Simple animation | Fun rich animation |
+
+## Phase plan
+
+### Phase 0 — Project reset and local foundation
+
+Goal: revive the repo cleanly without carrying old divergence as technical debt.
+
+Tasks:
+
+- Rename legacy repo to `omni-scoreboard-legacy`.
+- Create new `omni-scoreboard` from current upstream history.
+- Add remotes: `origin`, `upstream`, `legacy`.
+- Confirm upstream current release and default branch.
+- Add this context pack to `docs/agent_context/` or equivalent.
+- Establish local path `/opt/omni-scoreboard`.
+- Run upstream in emulator mode.
+- Run upstream on hardware if available.
+- Create `main` and first `agent/bootstrap-foundation` branch.
+
+Definition of done:
+
+- `git remote -v` is correct.
+- `python3 main.py --emulated` or upstream equivalent launches.
+- A README note documents the legacy remote and migration strategy.
+- A first PR exists or the first bootstrap commit is pushed.
+
+### Phase 1 — Typed domain core
+
+Goal: stop primitives from leaking through the project.
+
+Tasks:
+
+- Add `omni/core/enum.py`, cribbed from the uploaded enum mixin style.
+- Add typed `League`, `Sport`, `PanelProfile`, `GameStatus`, `CardKind`, `PriorityBand`, and `UpdateUrgency` enums.
+- Add value objects for IDs, timestamps, durations, colors, logos, display dimensions, panel profiles, and source metadata.
+- Define base `Competitor`, `Team`, `Athlete`, `Contest`, `GameEvent`, and `ScoreboardCard` classes.
+- Add sport-specific event type enums, beginning with `BaseballGameEventType`.
+- Add `BaseballTeam`, `FootballTeam`, `BasketballTeam`, `HockeyTeam`, and `Golfer`/`GolfCompetitor` domain classes.
+- Add `from __future__ import annotations`, `slots=True`, `frozen=True` value objects where practical.
+- Add mypy/pyright guardrails incrementally.
+
+Definition of done:
+
+- No new core code accepts raw league strings or team strings except at API/config boundaries.
+- Provider code converts raw API data into domain objects immediately.
+- Renderer code consumes domain/card objects rather than raw provider JSON.
+
+### Phase 2 — Display profiles and preview/snapshot tooling
+
+Goal: make all three supported layouts real and testable.
+
+Tasks:
+
+- Add `DisplayProfile` definitions:
+  - `single_64x32`
+  - `stack_64x64`
+  - `quad_128x64`
+- Map profiles to matrix flags/config.
+- Add renderer contract: each card declares supported profiles and fallback behavior.
+- Add emulator preview command.
+- Add fixture record/replay command.
+- Add PNG snapshot generation per profile.
+- Add golden-image tests for spacing-sensitive cards.
+
+Definition of done:
+
+```bash
+omni preview --profile single_64x32 --fixture fixtures/mlb/live-close-game.json
+omni preview --profile stack_64x64 --fixture fixtures/mlb/live-close-game.json
+omni preview --profile quad_128x64 --fixture fixtures/mlb/live-close-game.json
+omni snapshot test
+```
+
+### Phase 3 — MLB excellence
+
+Goal: make MLB delightful and reliable before expanding leagues.
+
+P0/P1 fixes:
+
+- Investigate and fix pregame cards halting the display permanently.
+- Implement TV-delay presets over upstream `sync_delay_seconds` semantics.
+- Fix team logo asset problems and background contrast.
+- Reinstate color-clash logic with alternate logo backgrounds.
+- Add probability-bar contrast validation.
+- Add SWPR pitch type mapping so it does not display as `UNKW`.
+- Fix stat-line debounce and horizontal bouncing.
+- Fix bot-right cards: sacs, RBI, complex plays.
+- Fix truncated fielder sequences like `9-6-4-`.
+- Fix end-of-game winner rendering: fade loser by winner, not screen position.
+- Tighten W/L/S pitcher rotation.
+- Nudge runline and extra-innings spacing.
+
+P2/P3 improvements:
+
+- Preserve last K / play-of-inning before mid/end-inning transition.
+- Add backwards K / K tracker.
+- Add no-hitter/perfect-game sticky priority.
+- Add challenge/ABS tightening.
+- Add idle-state ticker for other games/news.
+- Add mid-inning linescore, especially on 64x64 and 128x64.
+- Add K-zone with pitch blips on 64x64/128x64; fallback on 64x32.
+- Add pitching-change transition card.
+- Add HR stats/arcs as fun rich-mode polish.
+
+Definition of done:
+
+- MLB runs well across all three profiles.
+- Fixture tests cover no-hitter, perfect-game, strikeout, challenge, pitching change, complex play, extra innings, final, and pregame states.
+- 64x32 does not feel like a broken crop of 128x64.
+
+### Phase 4 — Delayed event queue and priority engine
+
+Goal: replace state-only rotation with an event/card queue.
+
+Core concepts:
+
+```text
+Provider raw data
+  -> Provider normalizer
+  -> Typed domain events
+  -> TV-delay buffer
+  -> Priority scorer
+  -> Interleaved card queue
+  -> Renderer selected by display profile
+  -> LED matrix / emulator
+```
+
+Requirements:
+
+- Events become eligible only after `source_time + selected_delay`.
+- Cards carry display timing, dedupe keys, priority reasons, and profile support.
+- Favorite-team and high-leverage events poll more often and display longer.
+- No-hitter/perfect-game, red-zone, late close game, cut-line, and final alerts can become sticky.
+- The queue interleaves sports rather than letting one provider monopolize the display.
+
+Priority signals:
+
+| Domain | High-priority signals |
+|---|---|
+| MLB | Favorite team, close late game, bases loaded, scoring play, HR, no-hitter/perfect-game, challenge/ABS, final |
+| NFL | Favorite team, red zone, scoring play, turnover, 2-minute drill, close late game, final |
+| NBA | Favorite team, clutch time, lead change, run, final minute, final |
+| NHL | Favorite team, power play, empty net, tie/one-goal late game, final |
+| PGA | Favorite golfers, majors, leader/cut-line movement, final-round back nine, playoff, cut sweat |
+
+Definition of done:
+
+- Queue behavior is deterministic under fixture replay.
+- TV delay prevents score spoilers for configured sources.
+- High-priority cards are visible without burying normal scoreboard updates.
+
+### Phase 5 — Friends-and-family setup, updater, and device behavior
+
+Goal: make a box that can be handed to someone.
+
+Setup:
+
+- First boot without Wi-Fi creates local AP: `OmniScoreboard-XXXX`.
+- Device shows setup URL/QR or simple setup text.
+- User configures Wi-Fi, favorite teams/golfers, display profile, time zone, brightness, delay preset, sleep schedule, and optional API keys.
+- Wi-Fi credentials stay local.
+- Hosted web page, if any, is docs/static helper only.
+
+Updater:
+
+- Use a `systemd` timer, not cron.
+- Fetch `origin/main` or `stable` daily and on startup.
+- Pull only fast-forward changes.
+- Validate config before restart.
+- Store previous commit for rollback.
+- Health-check service after restart.
+
+Power/schedule:
+
+- User-defined sleep/wake schedule.
+- Night dimming.
+- Optional favorite-game wake override.
+- GPIO physical switch:
+  - Short press: display on/off.
+  - Long press: setup mode.
+  - Very long press: safe shutdown.
+
+Definition of done:
+
+- A family unit can be imaged, booted, configured locally, and updated without SSH.
+
+### Phase 6 — NFL
+
+Goal: first non-MLB league.
+
+Data:
+
+- Start with ESPN site API scoreboard data.
+- Treat ESPN as unofficial/fragile; isolate behind provider interface.
+- Add optional commercial fallback later only if needed.
+
+Minimum cards:
+
+- Pregame: matchup, kickoff, records, spread/total if available.
+- Live: score, quarter, clock, possession, down/distance.
+- Priority: red zone, score, turnover, 2-minute drill, close late game.
+- Final: winner, score, key stat.
+
+Definition of done:
+
+- Favorite NFL team can be followed across all three display profiles with TV delay and priority queue integration.
+
+### Phase 7 — NBA
+
+Goal: frequent-game league with simpler event model than baseball.
+
+Cards:
+
+- Pregame matchup.
+- Live score/period/clock.
+- Lead change.
+- Close late-game sticky.
+- Final/top scorer.
+
+Definition of done:
+
+- Favorite NBA team support works and interleaves sanely with MLB/NFL.
+
+### Phase 8 — NHL
+
+Goal: add hockey with power-play and close-game urgency.
+
+Cards:
+
+- Pregame matchup.
+- Live score/period/clock/shots if available.
+- Power play.
+- Goal alert.
+- Empty net / late close game.
+- Final.
+
+Definition of done:
+
+- Favorite NHL team support works across all display profiles.
+
+### Phase 9 — PGA
+
+Goal: support tournament/leaderboard viewing before NCAA.
+
+Data:
+
+- Start with ESPN PGA scoreboard endpoint for schedule/current tournament/leaderboard.
+- Consider DataGolf API for live model probabilities and finish/cut-line probabilities if low-cost access fits.
+- Consider SportsDataIO Golf only if a paid/trial feed becomes necessary.
+
+Product concept:
+
+PGA is not team-vs-team. It should use favorite golfers, tournament importance, leaderboard volatility, cut-line movement, and final-round pressure.
+
+Minimum cards:
+
+- Current tournament summary.
+- Favorite golfer card: position, total, today, thru, next tee time if available.
+- Leaderboard top 3/5.
+- Cut-line card on Friday.
+- Final-round back-nine pressure card.
+- Playoff/final winner card.
+
+Priority:
+
+- Favorite golfer within 3 shots of lead.
+- Favorite golfer near cut line.
+- Major championship.
+- Final round, back nine.
+- Lead change.
+- Playoff.
+
+Definition of done:
+
+- User can follow selected golfers and majors without needing paid data by default.
+
+### Phase 10 — NCAA later
+
+Goal: only after pro sports plus PGA are stable.
+
+NCAA has high data complexity: many teams, rankings, bowls, tournaments, neutral sites, conferences, and inconsistent event payloads. Treat as a later expansion.
+
+## Open decisions
+
+- Do we require GitHub-recognized fork metadata, or is a normal repo cloned from upstream with an `upstream` remote enough?
+- Do we target Python 3.10+ to match upstream runtime checks or push toward a newer typed baseline once hardware images are confirmed?
+- Do we add Pydantic for config/API boundary validation or keep runtime dependencies lighter with dataclasses plus explicit parsing?
+- What exact 64x64 physical panel arrangement is preferred: two 64x32 panels stacked vertically, or native 64x64 panel? The logical profile should support both where matrix flags allow.
+- Should odds/probability be disabled by default to avoid API keys, or enabled where free endpoints suffice?

--- a/docs/agent_context/kernel/SOURCES.md
+++ b/docs/agent_context/kernel/SOURCES.md
@@ -1,0 +1,30 @@
+# Research basis
+
+This context pack was prepared on 2026-06-14.
+
+Primary repositories and references:
+
+- Current legacy repo: https://github.com/ajszoke/omni-scoreboard
+- Upstream source repo: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard
+- Upstream compare against legacy: https://github.com/ajszoke/omni-scoreboard/compare/master...MLB-LED-Scoreboard:mlb-led-scoreboard:master
+- Upstream releases: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/releases
+- Upstream plugin API docs: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/blob/master/bullpen/README.md
+- Upstream config example: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/blob/master/config.example.json
+- GitHub CLI fork docs: https://cli.github.com/manual/gh_repo_fork
+- GitHub CLI rename docs: https://cli.github.com/manual/gh_repo_rename
+- GitHub double-fork caveat: https://github.com/cli/cli/issues/6329
+- ESPN NFL scoreboard JSON endpoint: https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard
+- ESPN NBA scoreboard JSON endpoint: https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard
+- ESPN PGA scoreboard JSON endpoint: https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard
+- DataGolf API: https://datagolf.com/api-access
+- SportsDataIO Golf API: https://sportsdata.io/pga-golf-api
+- Tidbyt product reference: https://tidbyt.com/
+- Tidbyt/Pixlet tooling: https://github.com/tidbyt/pixlet
+- Gidger Raspberry Pi sports scoreboard reference: https://github.com/gidger/rpi-led-nhl-scoreboard
+- Ty Porter LED scoreboard hardware/dev-env writeup: https://blog.ty-porter.dev/development/raspberry%20pi/emulation/2021/11/11/building-raspberry-pi-led-scoreboards.html
+
+Local execution note:
+
+- Browser-based GitHub access worked.
+- Shell-level DNS inside the sandbox did not work: `getent hosts github.com` returned no host and `git ls-remote https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git` failed with `Could not resolve host: github.com`.
+- Local Claude Code should retry all git commands on the user's machine; the sandbox DNS failure should not be assumed to apply locally.

--- a/docs/agent_context/kernel/starter_code/domain_model_sketch.py
+++ b/docs/agent_context/kernel/starter_code/domain_model_sketch.py
@@ -1,0 +1,302 @@
+"""Typed domain model sketch for Omni Scoreboard.
+
+This is intentionally a sketch, not a finished module. Use it to guide the
+first implementation pass and split into proper packages as the repo evolves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Generic, Protocol, TypeVar
+
+from starter_code.enum_core import (
+    BaseballGameEventType,
+    CardKind,
+    DisplayPriority,
+    GameStatus,
+    League,
+    PanelProfile,
+    Sport,
+    UpdateUrgency,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRef:
+    name: str
+    raw_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LeagueScopedId:
+    league: League
+    source: SourceRef
+    raw: str
+
+    def __str__(self) -> str:
+        return f"{self.league}:{self.source.name}:{self.raw}"
+
+
+@dataclass(frozen=True, slots=True)
+class DurationSeconds:
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value < 0:
+            raise ValueError("duration cannot be negative")
+
+    def as_timedelta(self) -> timedelta:
+        return timedelta(seconds=self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class RGBColor:
+    r: int
+    g: int
+    b: int
+
+    def __post_init__(self) -> None:
+        for component in (self.r, self.g, self.b):
+            if not 0 <= component <= 255:
+                raise ValueError("RGB components must be 0..255")
+
+    def relative_luminance(self) -> float:
+        def convert(channel: int) -> float:
+            c = channel / 255
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+        return 0.2126 * convert(self.r) + 0.7152 * convert(self.g) + 0.0722 * convert(self.b)
+
+    def contrast_ratio(self, other: "RGBColor") -> float:
+        lighter = max(self.relative_luminance(), other.relative_luminance())
+        darker = min(self.relative_luminance(), other.relative_luminance())
+        return (lighter + 0.05) / (darker + 0.05)
+
+
+@dataclass(frozen=True, slots=True)
+class LogoAsset:
+    key: str
+    path: str
+    preferred_background: RGBColor | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PanelGeometry:
+    profile: PanelProfile
+    width: int
+    height: int
+    chain_length: int
+    parallel: int
+
+
+class Competitor(Protocol):
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class Team:
+    id: LeagueScopedId
+    league: League
+    display_name: str
+    short_name: str
+    abbreviation: str
+    primary_color: RGBColor
+    secondary_color: RGBColor
+    logo: LogoAsset
+
+    def best_text_color_on_primary(self) -> RGBColor:
+        white = RGBColor(255, 255, 255)
+        black = RGBColor(0, 0, 0)
+        return white if white.contrast_ratio(self.primary_color) >= black.contrast_ratio(self.primary_color) else black
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballTeam(Team):
+    division: str | None = None
+    league_side: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FootballTeam(Team):
+    conference: str | None = None
+    division: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BasketballTeam(Team):
+    conference: str | None = None
+    division: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HockeyTeam(Team):
+    conference: str | None = None
+    division: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Golfer:
+    id: LeagueScopedId
+    display_name: str
+    short_name: str
+    country: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Contest:
+    id: LeagueScopedId
+    league: League
+    status: GameStatus
+    scheduled_start: datetime
+    competitors: tuple[Competitor, ...]
+    venue_name: str | None = None
+
+    @property
+    def sport(self) -> Sport:
+        return self.league.sport
+
+
+@dataclass(frozen=True, slots=True)
+class TeamGame(Contest):
+    away: Team | None = None
+    home: Team | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GolfTournament(Contest):
+    tournament_name: str = ""
+    round_number: int | None = None
+    cut_line: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EventImportance:
+    priority: DisplayPriority
+    urgency: UpdateUrgency
+    leverage: float
+    rarity: float
+    favorite_relevance: float
+    reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("leverage", self.leverage),
+            ("rarity", self.rarity),
+            ("favorite_relevance", self.favorite_relevance),
+        ):
+            if not 0 <= value <= 1:
+                raise ValueError(f"{name} must be normalized 0..1")
+
+    def combined_score(self) -> float:
+        return (
+            int(self.priority)
+            + int(self.urgency) * 5
+            + self.leverage * 20
+            + self.rarity * 15
+            + self.favorite_relevance * 20
+        )
+
+
+EventTypeT = TypeVar("EventTypeT", bound=Enum)
+PayloadT = TypeVar("PayloadT")
+
+
+@dataclass(frozen=True, slots=True)
+class GameEvent(Generic[EventTypeT, PayloadT]):
+    id: LeagueScopedId
+    contest: Contest
+    event_type: EventTypeT
+    source: SourceRef
+    source_time: datetime
+    observed_at: datetime
+    competitors: tuple[Competitor, ...]
+    importance: EventImportance
+    payload: PayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballCount:
+    balls: int
+    strikes: int
+    outs: int
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballPlayPayload:
+    inning: int
+    half: str
+    count: BaseballCount | None
+    description: str
+    rbi: int = 0
+    pitch_type: str | None = None
+    fielder_sequence: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class BaseballGameEvent(GameEvent[BaseballGameEventType, BaseballPlayPayload]):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class CardId:
+    raw: str
+
+
+@dataclass(frozen=True, slots=True)
+class DedupeKey:
+    raw: str
+
+
+@dataclass(frozen=True, slots=True)
+class DisplayTiming:
+    available_at: datetime
+    expires_at: datetime | None
+    min_display: DurationSeconds
+    max_display: DurationSeconds
+
+    def is_available(self, now: datetime) -> bool:
+        return now >= self.available_at and (self.expires_at is None or now < self.expires_at)
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutSupport:
+    profiles: frozenset[PanelProfile]
+    fallback_card_kind: CardKind | None = None
+    compromise_notes: tuple[str, ...] = ()
+
+    def supports(self, profile: PanelProfile) -> bool:
+        return profile in self.profiles
+
+
+@dataclass(frozen=True, slots=True)
+class CardPriority:
+    band: DisplayPriority
+    score: float
+    reasons: tuple[str, ...]
+
+
+CardPayloadT = TypeVar("CardPayloadT")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreboardCard(Generic[CardPayloadT]):
+    id: CardId
+    kind: CardKind
+    contest: Contest
+    source_event_ids: tuple[LeagueScopedId, ...]
+    timing: DisplayTiming
+    priority: CardPriority
+    layout_support: LayoutSupport
+    dedupe_key: DedupeKey
+    payload: CardPayloadT
+
+    @property
+    def league(self) -> League:
+        return self.contest.league

--- a/docs/agent_context/kernel/starter_code/enum_core.py
+++ b/docs/agent_context/kernel/starter_code/enum_core.py
@@ -1,0 +1,217 @@
+"""Omni typed enum mixins and initial enums.
+
+Cribbed in spirit from the user's Alpine enum.py:
+
+- StrEnumMixin: string identifier enums where the string is canonical.
+- IntEnumMixin: ordered severity/priority enums backed by IntEnum.
+- try_coerce_enum: tolerant coercion for config/fixture/replay readers.
+
+Strict construction paths should still fail fast. Use try_coerce_enum only at
+boundaries where malformed historical input should not crash inspection tools.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum
+from typing import Any, TypeVar
+
+E = TypeVar("E", bound=Enum)
+
+
+def try_coerce_enum(enum_cls: type[E], raw: Any) -> E | None:
+    """Best-effort coerce raw input into an enum member; return None on failure."""
+    if isinstance(raw, enum_cls):
+        return raw
+    if isinstance(raw, bool):
+        return None
+    try:
+        return enum_cls(raw)
+    except (ValueError, KeyError, TypeError):
+        pass
+    if isinstance(raw, str):
+        try:
+            return enum_cls[raw.upper()]
+        except KeyError:
+            return None
+    return None
+
+
+class EnumMixin:
+    """Base for Omni typed enum mixins."""
+
+    def to_json_value(self) -> str | int:
+        return self.value  # type: ignore[attr-defined]
+
+
+class StrEnumMixin(EnumMixin):
+    """Mixin for str-backed enums where str(member) returns the raw value."""
+
+    def __str__(self) -> str:
+        return self.value  # type: ignore[attr-defined]
+
+
+class IntEnumMixin(EnumMixin):
+    """Mixin for ordered IntEnum-backed severities/priorities."""
+
+    def __str__(self) -> str:
+        return self.name.lower()  # type: ignore[attr-defined]
+
+    def to_json_value(self) -> str:
+        return self.name.lower()  # type: ignore[attr-defined]
+
+
+class Sport(StrEnumMixin, str, Enum):
+    BASEBALL = "baseball"
+    FOOTBALL = "football"
+    BASKETBALL = "basketball"
+    HOCKEY = "hockey"
+    GOLF = "golf"
+
+
+class League(StrEnumMixin, str, Enum):
+    MLB = "mlb"
+    NFL = "nfl"
+    NBA = "nba"
+    NHL = "nhl"
+    PGA = "pga"
+    NCAAF = "ncaaf"
+    NCAAB = "ncaab"
+
+    @property
+    def sport(self) -> Sport:
+        return {
+            League.MLB: Sport.BASEBALL,
+            League.NFL: Sport.FOOTBALL,
+            League.NBA: Sport.BASKETBALL,
+            League.NHL: Sport.HOCKEY,
+            League.PGA: Sport.GOLF,
+            League.NCAAF: Sport.FOOTBALL,
+            League.NCAAB: Sport.BASKETBALL,
+        }[self]
+
+
+class PanelProfile(StrEnumMixin, str, Enum):
+    SINGLE_64X32 = "single_64x32"
+    STACK_64X64 = "stack_64x64"
+    QUAD_128X64 = "quad_128x64"
+
+
+class GameStatus(StrEnumMixin, str, Enum):
+    SCHEDULED = "scheduled"
+    PREGAME = "pregame"
+    LIVE = "live"
+    DELAYED = "delayed"
+    SUSPENDED = "suspended"
+    FINAL = "final"
+    POSTPONED = "postponed"
+    CANCELED = "canceled"
+    UNKNOWN = "unknown"
+
+
+class CardKind(StrEnumMixin, str, Enum):
+    LIVE_GAME = "live_game"
+    BIG_PLAY = "big_play"
+    PREGAME = "pregame"
+    FINAL = "final"
+    TICKER = "ticker"
+    ALERT = "alert"
+    LEADERBOARD = "leaderboard"
+    SETUP = "setup"
+    OFFDAY = "offday"
+
+
+class DisplayPriority(IntEnumMixin, IntEnum):
+    BACKGROUND = 0
+    NORMAL = 10
+    FAVORITE = 20
+    HIGH_LEVERAGE = 30
+    ALERT = 40
+    STICKY = 50
+
+
+class UpdateUrgency(IntEnumMixin, IntEnum):
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    LIVE_CRITICAL = 3
+
+
+class BaseballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    PITCH = "pitch"
+    BALL = "ball"
+    CALLED_STRIKE = "called_strike"
+    SWINGING_STRIKE = "swinging_strike"
+    FOUL = "foul"
+    BALL_IN_PLAY = "ball_in_play"
+    STRIKEOUT_LOOKING = "strikeout_looking"
+    STRIKEOUT_SWINGING = "strikeout_swinging"
+    WALK = "walk"
+    HIT_BY_PITCH = "hit_by_pitch"
+    SINGLE = "single"
+    DOUBLE = "double"
+    TRIPLE = "triple"
+    HOME_RUN = "home_run"
+    SAC_FLY = "sac_fly"
+    SAC_BUNT = "sac_bunt"
+    DOUBLE_PLAY = "double_play"
+    TRIPLE_PLAY = "triple_play"
+    RUN_SCORED = "run_scored"
+    RBI = "rbi"
+    PITCHING_CHANGE = "pitching_change"
+    CHALLENGE = "challenge"
+    ABS_CHALLENGE = "abs_challenge"
+    INNING_START = "inning_start"
+    HALF_INNING_END = "half_inning_end"
+    GAME_FINAL = "game_final"
+    NO_HITTER_ACTIVE = "no_hitter_active"
+    NO_HITTER_BROKEN = "no_hitter_broken"
+    PERFECT_GAME_ACTIVE = "perfect_game_active"
+    PERFECT_GAME_BROKEN = "perfect_game_broken"
+
+
+class FootballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    DRIVE_START = "drive_start"
+    RED_ZONE = "red_zone"
+    SCORE = "score"
+    TOUCHDOWN = "touchdown"
+    FIELD_GOAL = "field_goal"
+    TURNOVER = "turnover"
+    TWO_MINUTE_WARNING = "two_minute_warning"
+    GAME_FINAL = "game_final"
+
+
+class BasketballGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    SCORE_CHANGE = "score_change"
+    LEAD_CHANGE = "lead_change"
+    CLUTCH_TIME = "clutch_time"
+    TIMEOUT = "timeout"
+    GAME_FINAL = "game_final"
+
+
+class HockeyGameEventType(StrEnumMixin, str, Enum):
+    GAME_SCHEDULED = "game_scheduled"
+    GAME_STARTED = "game_started"
+    GOAL = "goal"
+    POWER_PLAY = "power_play"
+    PENALTY = "penalty"
+    EMPTY_NET = "empty_net"
+    OVERTIME = "overtime"
+    SHOOTOUT = "shootout"
+    GAME_FINAL = "game_final"
+
+
+class GolfEventType(StrEnumMixin, str, Enum):
+    TOURNAMENT_SCHEDULED = "tournament_scheduled"
+    ROUND_STARTED = "round_started"
+    LEADERBOARD_UPDATE = "leaderboard_update"
+    FAVORITE_MOVED = "favorite_moved"
+    CUT_LINE_UPDATE = "cut_line_update"
+    LEAD_CHANGE = "lead_change"
+    PLAYOFF = "playoff"
+    TOURNAMENT_FINAL = "tournament_final"


### PR DESCRIPTION
Stands up the **head/hand external-review cadence**: the external flagship model (ChatGPT, "CGPT") plans; Claude Code implements + self-reviews against the original plan. Two additive pieces, **no code change**.

## `docs/agent_context/kernel/` — the frozen seed
The verbatim `omni_scoreboard_context_pack` CGPT authored on 2026-06-14 to seed this project (AGENTS / ROADMAP / ARCHITECTURE / BACKLOG / SOURCES + the bootstrap prompt + `starter_code/`). This is the **drift-review baseline** — never edited; each review round diffs the as-built repo against it. `PROVENANCE.md` records the posture and the living-vs-frozen split. (The frozen `starter_code/*.py` is already excluded from mypy/black by the existing `starter_code/` rule — gate stays clean at 149/148 files.)

## `.claude/skills/external-review/` — the cadence
The **plan-trio + round-zip** pattern (adapted from the day-job Shopfine skill): self-review vs. the kernel, fix clear drifts yourself, then bundle an immutable `round-N.zip` + prompt for the flagship to (a) confirm fidelity, (b) bless/redirect deliberate deviations, (c) sequence the next phase. `SKILL.md` (scannable loop) + `reference.md` (conventions, the kernel-diff method) + `templates.md` (skeletons).

## Why
You reframed "review" as a handoff to the flagship planner, not `/code-review`. This houses my kernel durably (your ask) and gives the review rounds a repeatable shape. The first round's bundle + prompt follow in the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)