### PR TITLE
docs: reconcile ARCHITECTURE layout with as-built (drift fix)

### DIFF
--- a/docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md
+++ b/docs/agent_context/ARCHITECTURE_TYPED_DOMAIN.md
@@ -83,6 +83,37 @@ omni/
 
 This can be introduced incrementally inside the upstream tree. Do not attempt a giant rewrite before the emulator works.
 
+### As-built reconciliation (2026-06-23, after PRs #1–#13)
+
+The package above is the *proposed* layout. It landed faithfully for `core/`, `domain/`, `events/`
+(all sport taxonomies), `cards/`, **`queue/` (exact)**, and `providers/`. The deviations below are
+deliberate; the renderer axis and sequencing are flagged for external review, not silently settled.
+
+- **`renderers/` — per-card, not per-profile.** Built `base.py` + a hardware-agnostic `Canvas`
+  protocol (`canvas.py`) with `RecordingCanvas`/`PillowCanvas`/`MatrixCanvas` adapters + `font.py`,
+  and one renderer per *card* (`live_baseball.py`) that handles all three profiles via
+  `assert_never` dispatch — instead of the proposed `profile_single_64x32.py` / `_stack_64x64` /
+  `_quad_128x64` modules. Rationale: a card's layout is cohesive across profiles, and the `Canvas`
+  seam lets one renderer drive a golden image, a recording double, or a real panel. **Axis inversion —
+  for the head to bless.**
+- **`core/serialization.py` — absent.** Serialization is inline on enums (`to_json_value()`); no
+  central module was needed yet.
+- **`panels/` — `geometry.py` only.** `PanelProfile` lives in `core/enum.py` (subsumes `profiles.py`);
+  the `layout_contract.py` concept is realized as `cards/base.py::LayoutSupport` + a renderer's
+  `supported_profiles`.
+- **`preview/` — `cli.py` + `scenario.py` + `__main__.py`.** `python -m omni.preview` replaces the
+  proposed `web.py`/`fixture_replay.py`; golden snapshots live in `tests/` (run via pytest) rather
+  than a `snapshot.py` module / `omni snapshot` CLI.
+- **`CardFactory` in `cards/factory.py`**, not `queue/` (it produces cards; the queue consumes them).
+- **Baseball value types** (`HalfInning`, `BaseballCount`, `BaseballBaseState`) + the live
+  `BaseballGameState` snapshot live in `domain/baseball.py` (relocated there in PR #9, re-exported
+  from `events`/`cards` for back-compat). **`providers/mlb_teams.py`** (the team registry) was added.
+- **Sequencing:** the queue (`omni/queue/`) was built before MLB feature-completeness, inverting the
+  kernel roadmap's "MLB polish → queue" order. MLB is live-card-only so far. **For the head to
+  sequence.**
+
+The frozen original layout is preserved at `docs/agent_context/kernel/`.
+
 ## Core enums
 
 ```python


### PR DESCRIPTION
The one **accidental drift** the self-review caught: `ARCHITECTURE_TYPED_DOMAIN.md`'s proposed package layout still describes modules that were never built (`renderers/profile_*.py`, `panels/profiles.py`, `core/serialization.py`, `preview/web.py`, …) — which misleads agents navigating the code.

Adds an **"As-built reconciliation"** subsection recording how the layout actually landed and why each deviation was made. Faithful for `core`/`domain`/`events`/`cards`/**`queue` (exact)**/`providers`; the deviations:

- **`renderers/` per-card, not per-profile** — a `Canvas` protocol (Recording/Pillow/Matrix adapters) + one renderer per card with `assert_never` profile dispatch. Axis inversion — **flagged for the head to bless.**
- `core/serialization.py` absent (inline `to_json_value()`); `panels/` is geometry-only; `preview/` is `cli.py`+`scenario.py`; `CardFactory` in `cards/`; baseball value types relocated to `domain/baseball.py`; `mlb_teams` registry added.
- **Sequencing:** queue built before MLB feature-completeness — **flagged for the head to sequence.**

The judgment-call deviations are deliberately *flagged*, not settled — they go to the flagship in round-1. Docs-only; no code change. Frozen original layout preserved at `docs/agent_context/kernel/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)