### PR TITLE
docs(skill): move review-round home to ~/omni-review/ (off Windows Downloads)

### DIFF
--- a/.claude/skills/external-review/SKILL.md
+++ b/.claude/skills/external-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-review
-description: Run a round of the head/hand external review — bundle the build state for the external flagship model (ChatGPT, "CGPT") to review fidelity-to-plan and steer the next phase, using the plan-trio + round-zip cadence. Use after a milestone/phase, before a framework-level direction change, or whenever the build needs the planner to bless deviations or sequence what's next. Produces a scannable plan-trio in ~/.claude/plans/ and an immutable round-N.zip + prompt to hand off. NOT for routine PRs, bug fixes, or single-file edits.
+description: Run a round of the head/hand external review — bundle the build state for the external flagship model (ChatGPT, "CGPT") to review fidelity-to-plan and steer the next phase, using the plan-trio + round-zip cadence. Use after a milestone/phase, before a framework-level direction change, or whenever the build needs the planner to bless deviations or sequence what's next. Produces a scannable plan-trio in ~/omni-review/plans/ and an immutable round-N.zip + prompt to hand off. NOT for routine PRs, bug fixes, or single-file edits.
 ---
 
 # External-review cadence (head/hand, plan-trio + round-zips)
@@ -31,20 +31,23 @@ Always state explicitly what's **current-ship** vs **deferred** and ask the head
 
 ## The artifacts
 
+All review artifacts live in one durable WSL home, `~/omni-review/` (machine-local — *not* in the repo):
+
 ```
-~/.claude/plans/
-  omni-<slug>.md             ← main plan / review brief, stays SCANNABLE
-  omni-<slug>-SUPPLEMENT.md  ← evidence locker: file:line touchpoints, in-code verifications, drift table
-  omni-<slug>-REVIEWS.md     ← per-round log: briefing + verbatim verdict + our adjudication
-~/scratchpad/omni-scoreboard/
-  round-N-prompt.md          ← the briefing handed to the flagship (also bundled)
-  round-N.zip                ← plans/ snapshot + prompt + sources/ + prior verdict
-  round-N-verdict.md         ← the flagship's verbatim verdict, archived per round
+~/omni-review/
+  plans/                       ← the living plan-trio, updated across rounds
+    omni-<slug>.md             ← main plan / review brief, stays SCANNABLE
+    omni-<slug>-SUPPLEMENT.md  ← evidence locker: file:line touchpoints, in-code verifications, drift table
+    omni-<slug>-REVIEWS.md     ← per-round log: briefing + verbatim verdict + our adjudication
+  rounds/                      ← immutable per-round bundles
+    round-N-prompt.md          ← the briefing handed to the flagship (also bundled)
+    round-N.zip                ← plans/ snapshot + prompt + sources/ + prior verdict
+    round-N-verdict.md         ← the flagship's verbatim verdict, archived per round
 ```
 
 `<slug>` is a stable memorable handle. **One zip per round, never overwrite — it's the audit trail.**
-Copy the final `round-N.zip` + `round-N-prompt.md` to a user-reachable spot (e.g. a Windows
-`Downloads/omni_review_round-N/` folder) so the user can upload them to the flagship.
+The home is reachable from Windows at `\\wsl.localhost\Ubuntu\home\<user>\omni-review\`, so the user can
+upload `rounds/round-N.zip` + `round-N-prompt.md` to the flagship directly — no copy into Downloads.
 
 ## The loop
 

--- a/.claude/skills/external-review/reference.md
+++ b/.claude/skills/external-review/reference.md
@@ -4,7 +4,7 @@ Detailed conventions for the [external-review](SKILL.md) skill. Skeletons in [te
 
 ---
 
-## 1. The plan-trio (`~/.claude/plans/`)
+## 1. The plan-trio (`~/omni-review/plans/`)
 
 Three sibling files sharing an `omni-<slug>` handle. The split keeps the main brief scannable.
 
@@ -18,7 +18,7 @@ Tag claims **[verified]** (read this session) vs **[reported]** (secondhand) in 
 
 ---
 
-## 2. The round-zip (`~/scratchpad/omni-scoreboard/`)
+## 2. The round-zip (`~/omni-review/rounds/`)
 
 ```
 round-N-prompt.md     ← authored FIRST, then a copy is bundled

--- a/.claude/skills/external-review/templates.md
+++ b/.claude/skills/external-review/templates.md
@@ -4,7 +4,7 @@ Copy-paste skeletons for the [external-review](SKILL.md) skill. Replace `<…>`.
 
 ---
 
-## A. Main brief — `~/.claude/plans/omni-<slug>.md`
+## A. Main brief — `~/omni-review/plans/omni-<slug>.md`
 
 ```markdown
 # Omni external review — <slug> (round N)
@@ -38,7 +38,7 @@ Copy-paste skeletons for the [external-review](SKILL.md) skill. Replace `<…>`.
 
 ---
 
-## B. SUPPLEMENT — `~/.claude/plans/omni-<slug>-SUPPLEMENT.md`
+## B. SUPPLEMENT — `~/omni-review/plans/omni-<slug>-SUPPLEMENT.md`
 
 ```markdown
 # Omni external review — <slug> — SUPPLEMENT
@@ -60,12 +60,12 @@ Companion to `omni-<slug>.md`. Citations: **[verified]** = read this session; **
 
 ---
 
-## C. REVIEWS — `~/.claude/plans/omni-<slug>-REVIEWS.md`
+## C. REVIEWS — `~/omni-review/plans/omni-<slug>-REVIEWS.md`
 
 ```markdown
 # Omni external review — <slug> — rounds
 
-Per-round log. Bundles at `~/scratchpad/omni-scoreboard/round-N.zip`.
+Per-round log. Bundles at `~/omni-review/rounds/round-N.zip`.
 
 ## Round N — [pending | date]
 **Bundle:** `round-N.zip`  **Briefing:** `round-N-prompt.md`
@@ -91,7 +91,7 @@ Stops when: clean "Proceed" + no open framing questions + all accepted findings 
 
 ---
 
-## D. Round-N briefing — `~/scratchpad/omni-scoreboard/round-N-prompt.md`
+## D. Round-N briefing — `~/omni-review/rounds/round-N-prompt.md`
 
 ```markdown
 # Omni Scoreboard — external review, round N (<fidelity + plan | converge>)


### PR DESCRIPTION
Per your ask — a durable WSL-side home for the review rounds instead of dumping them in Windows Downloads.

**New home:** `~/omni-review/` — `plans/` (the living plan-trio) + `rounds/` (immutable per-round `zip`/`prompt`/`verdict`). Reachable from Windows at `\\wsl.localhost\Ubuntu\home\andy\omni-review\`, so you can upload `round-N.zip` + prompt straight to the flagship — no copy into Downloads.

Replaces the earlier scattered split (`~/.claude/plans/` + `~/scratchpad/omni-scoreboard/` + a Downloads dump). Updates `SKILL.md` / `reference.md` / `templates.md` to the new convention. The round-1 artifacts were physically relocated to match (and the Downloads copy removed); memory updated too. Skill docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)