### PR TITLE
A0(1): harden invariants flagged by the round-1 verdict

### DIFF
--- a/omni/cards/base.py
+++ b/omni/cards/base.py
@@ -46,12 +46,29 @@ class DedupeKey:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class DisplayTiming:
-    """When a card may show and for how long — typed instead of loose datetimes/ints."""
+    """When a card may show and for how long — typed instead of loose datetimes/ints.
+
+    Validated on construction so a long-running appliance fails fast rather than
+    silently comparing naive vs. aware datetimes (or holding an already-expired
+    or zero/negative-window card): every datetime must be timezone-aware,
+    ``min_display <= max_display``, and any ``expires_at`` must be after
+    ``available_at``.
+    """
 
     available_at: datetime
     min_display: DurationSeconds
     max_display: DurationSeconds
     expires_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.available_at.tzinfo is None:
+            raise ValueError("available_at must be timezone-aware")
+        if self.expires_at is not None and self.expires_at.tzinfo is None:
+            raise ValueError("expires_at must be timezone-aware")
+        if self.min_display.value > self.max_display.value:
+            raise ValueError("min_display cannot exceed max_display")
+        if self.expires_at is not None and self.expires_at <= self.available_at:
+            raise ValueError("expires_at must be after available_at")
 
     def is_available(self, now: datetime) -> bool:
         return now >= self.available_at and (self.expires_at is None or now < self.expires_at)

--- a/omni/cards/factory.py
+++ b/omni/cards/factory.py
@@ -4,8 +4,11 @@ This is the seam between "what the game is" (domain `BaseballGameState`) and
 "how a card shows it" (a `LiveBaseballCardPayload` plus display metadata). It is
 pure — no I/O, no provider JSON — so it is fully unit-testable.
 
-TV-delay (`available_at` offset) and real priority scoring arrive with the queue
-layer; for now timing starts at `now` and priority defaults to NORMAL.
+The factory stays pure: it stamps timing from the `now` it is handed and takes an
+already-scored `priority` (defaulting to NORMAL only when none is supplied). The
+queue layer wires the real values around it — `PriorityScorer` produces the
+priority, and the TV-delay is applied to the timing upstream (a typed delay
+policy in the forthcoming orchestration spine, not inside the factory).
 """
 
 from __future__ import annotations

--- a/omni/domain/contest.py
+++ b/omni/domain/contest.py
@@ -28,6 +28,11 @@ class Contest:
     competitors: tuple[Competitor, ...] = ()
     venue_name: str | None = None
 
+    def __post_init__(self) -> None:
+        # `league` is also carried by `id`; they must never disagree.
+        if self.league != self.id.league:
+            raise ValueError(f"contest league {self.league} disagrees with id.league {self.id.league}")
+
     @property
     def sport(self) -> Sport:
         return self.league.sport
@@ -41,11 +46,14 @@ class TeamGame(Contest):
     home: Team
 
     def __post_init__(self) -> None:
+        # Explicit parent call (not `super()`): `@dataclass(slots=True)` rebuilds
+        # the class, so a zero-arg `super()` would resolve to the pre-slots class.
+        Contest.__post_init__(self)  # league/id consistency
         if self.away == self.home:
             raise ValueError("home and away teams must differ")
-        if not self.competitors:
-            # Keep the general `competitors` view consistent with home/away.
-            object.__setattr__(self, "competitors", (self.away, self.home))
+        # Always derive the general `competitors` view from home/away so the two
+        # can never contradict each other; any caller-supplied tuple is ignored.
+        object.__setattr__(self, "competitors", (self.away, self.home))
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/omni/domain/teams.py
+++ b/omni/domain/teams.py
@@ -25,6 +25,11 @@ class Team:
     secondary_color: RGBColor
     logo: LogoAsset
 
+    def __post_init__(self) -> None:
+        # `league` is also carried by `id`; they must never disagree.
+        if self.league != self.id.league:
+            raise ValueError(f"team league {self.league} disagrees with id.league {self.id.league}")
+
     def best_text_color_on_primary(self) -> RGBColor:
         """White or black text, whichever contrasts better on the primary color."""
         white = RGBColor(255, 255, 255)

--- a/omni/providers/mlb_statsapi.py
+++ b/omni/providers/mlb_statsapi.py
@@ -1,12 +1,10 @@
 """MLB provider backed by the MLB StatsAPI `schedule` endpoint.
 
-Parses the flat rows that `statsapi.schedule(...)` returns into typed `TeamGame`
-contests (matchup + status + start + venue). The raw dict shape is confined to
-this module; everything it returns is typed.
-
-Live game state (score, inning, count, bases) comes from the richer per-game
-feed and lands with the `CardFactory` in a later step — this provider answers
-"who is playing, when, and what's the status".
+Two calls, both confined to this module's raw dict shape: `refresh(now)` is one
+cheap `statsapi.schedule(...)` call parsed into typed `TeamGame` contests
+(matchup + status + start + venue); `fetch_game_state(game_pk)` pulls one game's
+richer per-game feed into a typed `BaseballGameState` (score, inning, count,
+bases). Everything either returns is typed.
 """
 
 from __future__ import annotations

--- a/omni/queue/delay_buffer.py
+++ b/omni/queue/delay_buffer.py
@@ -5,8 +5,11 @@ feed. Pushing every observation through a `DelayBuffer` set to that lag means th
 scoreboard reveals a run/score only once the watcher could have seen it too.
 
 Generic over the held item (a card, an event, a state) so one mechanism serves
-the whole pipeline. The buffer owns delay timing only; priority-based bypass
-(e.g. letting an ALERT skip the delay) is a queue-policy concern layered on top.
+the whole pipeline. The buffer owns delay timing only. **Display priority never
+shortens the delay** — a sports ALERT (walk-off, no-hitter) is exactly the most
+spoiler-heavy content, so it waits like everything else. Only a separate
+system/setup status (network fault, configuration), which is not sports content,
+may use a different policy; that lives outside this buffer.
 """
 
 from __future__ import annotations

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from omni.cards.base import (
     CardId,
     CardKind,
@@ -71,3 +73,34 @@ def test_display_timing_without_expiry_is_available_indefinitely() -> None:
     assert not timing.is_available(T - timedelta(seconds=1))
     assert timing.is_available(T)
     assert timing.is_available(T + timedelta(days=3650))  # no expires_at -> available far in the future
+
+
+def test_display_timing_rejects_naive_available_at() -> None:
+    naive = datetime(2026, 6, 17, 19, 5)  # no tzinfo
+    with pytest.raises(ValueError, match="available_at must be timezone-aware"):
+        DisplayTiming(available_at=naive, min_display=DurationSeconds(5), max_display=DurationSeconds(30))
+
+
+def test_display_timing_rejects_naive_expires_at() -> None:
+    with pytest.raises(ValueError, match="expires_at must be timezone-aware"):
+        DisplayTiming(
+            available_at=T,
+            expires_at=datetime(2026, 6, 17, 20, 5),  # no tzinfo
+            min_display=DurationSeconds(5),
+            max_display=DurationSeconds(30),
+        )
+
+
+def test_display_timing_rejects_min_display_above_max() -> None:
+    with pytest.raises(ValueError, match="min_display cannot exceed max_display"):
+        DisplayTiming(available_at=T, min_display=DurationSeconds(31), max_display=DurationSeconds(30))
+
+
+def test_display_timing_rejects_expiry_at_or_before_availability() -> None:
+    with pytest.raises(ValueError, match="expires_at must be after available_at"):
+        DisplayTiming(
+            available_at=T,
+            expires_at=T,  # not strictly after
+            min_display=DurationSeconds(5),
+            max_display=DurationSeconds(30),
+        )

--- a/tests/test_domain_contest.py
+++ b/tests/test_domain_contest.py
@@ -73,8 +73,9 @@ def test_team_game_requires_distinct_teams() -> None:
         )
 
 
-def test_team_game_preserves_explicit_competitors() -> None:
-    # A provider may supply `competitors` itself; don't overwrite it.
+def test_team_game_derives_competitors_ignoring_contradictory_input() -> None:
+    # Even when a caller supplies a contradictory `competitors`, the canonical
+    # view is always derived from (away, home) so the two cannot disagree.
     away = make_team("115", "Colorado Rockies", "COL")
     home = make_team("119", "Los Angeles Dodgers", "LAD")
     game = TeamGame(
@@ -82,11 +83,35 @@ def test_team_game_preserves_explicit_competitors() -> None:
         league=League.MLB,
         status=GameStatus.LIVE,
         scheduled_start=KICKOFF,
-        competitors=(home, away),  # deliberately reversed
+        competitors=(home, away),  # deliberately reversed — must be overridden
         away=away,
         home=home,
     )
-    assert game.competitors == (home, away)
+    assert game.competitors == (away, home)
+
+
+def test_contest_rejects_league_disagreeing_with_id() -> None:
+    with pytest.raises(ValueError, match="disagrees with id.league"):
+        Contest(
+            id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "g1"),
+            league=League.NFL,  # disagrees with id.league
+            status=GameStatus.SCHEDULED,
+            scheduled_start=KICKOFF,
+        )
+
+
+def test_team_rejects_league_disagreeing_with_id() -> None:
+    with pytest.raises(ValueError, match="disagrees with id.league"):
+        Team(
+            id=LeagueScopedId(League.MLB, SourceRef("mlb_statsapi"), "115"),
+            league=League.NFL,  # disagrees with id.league
+            display_name="Colorado Rockies",
+            short_name="Rockies",
+            abbreviation="COL",
+            primary_color=RGBColor(51, 0, 111),
+            secondary_color=RGBColor(196, 206, 212),
+            logo=LogoAsset(key="col", path="assets/col.png"),
+        )
 
 
 def test_golf_tournament_holds_individual_competitors() -> None:

--- a/tests/test_queue_scheduler.py
+++ b/tests/test_queue_scheduler.py
@@ -91,7 +91,8 @@ def test_card_is_not_shown_before_its_available_at() -> None:
 
 def test_expired_cards_are_pruned_and_not_shown() -> None:
     queue = InterleavedCardQueue()
-    queue.ingest(_card("g1", expires_at=NOW))  # now >= expires_at -> gone
+    # Available a minute ago, expiring exactly at NOW: now >= expires_at -> gone.
+    queue.ingest(_card("g1", available_at=NOW - timedelta(seconds=60), expires_at=NOW))
     assert len(queue) == 1
     assert queue.next_card(NOW, QUAD) is None
     assert len(queue) == 0


### PR DESCRIPTION
First increment of the head-sequenced **A0 (orchestration spine + semantic hardening)** phase. Closes the *contained* correctness gaps from the CGPT round-1 verdict so the appliance fails fast instead of silently mis-rotating. Pure value-object hardening — **no behavior change to the live pipeline** (verified: `omni preview` still builds its card; full dogfood below).

## Changes (each → verdict finding)
- **`DisplayTiming` fail-fast validation** — timezone-aware datetimes, `min_display <= max_display`, `expires_at` strictly after `available_at` *(High #5; A0's "fail fast on naive/mixed timing values")*.
- **Domain identity consistency** — `Team`/`Contest` reject a `league` that disagrees with `id.league`; `TeamGame.competitors` is now derived **unconditionally** from `(away, home)` so the two can never contradict *(Medium #2 + open-question #5)*.
- **Doc refresh** — `CardFactory` + MLB-provider headers (the queue layer and live-state both shipped); the `DelayBuffer` docstring no longer proposes a display-priority delay bypass — **a sports ALERT never skips the TV delay** *(High #2 doc half + Low #1)*.

> The behavioral half of High #2 (anchor the delay to `source_time`, not `observed_at`) and the rest of A0 (Clock, `DelayPolicy`, `AttentionPolicy`, two-level queue, `RendererRegistry`) follow in subsequent A0 PRs.

## QC
- **275 pass** (+6 new: 4 `DisplayTiming` guards, 2 identity-mismatch; flips the old preserve-contradictory-competitors test to assert derivation). `omni/` **99% line / 100% branch**.
- `mypy .` clean (148 files) · `black --check .` clean.
- Dogfood: factory builds a card with aware `now`; naive `now` raises; `league`-mismatch raises.

Implementation note: `TeamGame.__post_init__` calls `Contest.__post_init__(self)` explicitly rather than `super()` — `@dataclass(slots=True)` rebuilds the class, so zero-arg `super()` resolves to the pre-slots class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)