### PR TITLE
B1: add CIE76 delta_e color difference to RGBColor

### DIFF
--- a/omni/core/colors.py
+++ b/omni/core/colors.py
@@ -1,11 +1,13 @@
-"""RGB color value object with WCAG luminance/contrast helpers.
+"""RGB color value object with WCAG luminance/contrast and CIELab difference.
 
 Used to pick legible text colors on team-colored backgrounds across the three
-panel profiles without hand-tuning per team.
+panel profiles without hand-tuning per team, and to measure how *distinct* two
+team colors are (`delta_e`) so clashing matchups can be told apart.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 __all__ = ["RGBColor"]
@@ -38,3 +40,39 @@ class RGBColor:
         lighter = max(self.relative_luminance(), other.relative_luminance())
         darker = min(self.relative_luminance(), other.relative_luminance())
         return (lighter + 0.05) / (darker + 0.05)
+
+    def delta_e(self, other: RGBColor) -> float:
+        """CIE76 color difference in L*a*b* (symmetric, 0.0 for identical colors).
+
+        Measures *perceived* distance, not raw RGB distance: ~2.3 is the just-
+        noticeable difference, and two team backgrounds within a small threshold
+        (~20) read as "the same color" on a small panel and need disambiguating.
+        """
+        l1 = _to_lab(self)
+        l2 = _to_lab(other)
+        return math.sqrt(sum((a - b) ** 2 for a, b in zip(l1, l2)))
+
+
+def _to_lab(color: RGBColor) -> tuple[float, float, float]:
+    """sRGB → CIE L*a*b* (D65) — the perceptually-uniform space `delta_e` measures in.
+
+    The XYZ luminance row carries the same 0.2126/0.7152/0.0722 human-perception
+    weighting as `relative_luminance`, so L* is a perceptual lightness (green reads
+    brighter than red brighter than blue at equal code value).
+    """
+
+    def linear(channel: int) -> float:
+        c = channel / 255
+        return ((c + 0.055) / 1.055) ** 2.4 if c > 0.04045 else c / 12.92
+
+    r, g, b = (linear(channel) * 100 for channel in (color.r, color.g, color.b))
+    # sRGB → XYZ (D65), then normalize by the reference white.
+    x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 95.047
+    y = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 100.0
+    z = (r * 0.0193 + g * 0.1192 + b * 0.9504) / 108.883
+
+    def pivot(t: float) -> float:
+        return t ** (1 / 3) if t > 0.008856 else 7.787 * t + 16 / 116
+
+    fx, fy, fz = pivot(x), pivot(y), pivot(z)
+    return (116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz))

--- a/tests/test_core_values.py
+++ b/tests/test_core_values.py
@@ -68,3 +68,25 @@ def test_relative_luminance_covers_both_srgb_branches() -> None:
     assert RGBColor(128, 128, 128).relative_luminance() == pytest.approx(0.2159, abs=0.002)
     # linear branch (channel <= 0.03928): near-black stays a small positive value
     assert 0.0 < RGBColor(2, 2, 2).relative_luminance() < 0.001
+
+
+def test_delta_e_identity_and_symmetry() -> None:
+    navy = RGBColor(12, 35, 64)
+    assert navy.delta_e(navy) == 0.0  # a colour is identical to itself
+    silver = RGBColor(196, 206, 212)
+    assert navy.delta_e(silver) == silver.delta_e(navy)  # CIE76 is symmetric
+
+
+def test_delta_e_black_to_white_spans_the_lightness_range() -> None:
+    # The full L* range is 100; this one call exercises both sRGB-linear branches
+    # and both Lab-pivot branches (bright cube-root vs dark linear).
+    assert RGBColor(0, 0, 0).delta_e(RGBColor(255, 255, 255)) == pytest.approx(100.0, abs=0.01)
+
+
+def test_delta_e_flags_clashing_navies_but_not_real_accents() -> None:
+    navy = RGBColor(12, 35, 64)  # NYY / DET background
+    assert navy.delta_e(RGBColor(0, 43, 92)) < 20  # CLE / MIN navy: a clash
+    assert navy.delta_e(RGBColor(19, 39, 79)) < 20  # ATL near-navy: a clash
+    # A real accent is unambiguously distinct — the basis for an alt background.
+    assert navy.delta_e(RGBColor(250, 70, 22)) > 20  # DET orange
+    assert navy.delta_e(RGBColor(196, 206, 212)) > 20  # silver


### PR DESCRIPTION
## What

Port the legacy `color_delta_e` onto `RGBColor` as a typed `delta_e(other)` method. This is **PR2a of the logo clash work** — the color-math foundation the alt-background policy is built on.

## How

- `RGBColor.delta_e(other)` — CIE76 difference: sRGB → CIE L\*a\*b\* (D65) via a private `_to_lab`, then Euclidean distance. A faithful port of legacy `utils.color_delta_e`/`rgb2lab` (verified equal to <1e-6).
- The Lab luminance row uses the same `0.2126/0.7152/0.0722` weighting as `relative_luminance`, so L\* is a perceptual lightness (the "human-RGB-perception skew") — which the upcoming value-lift legibility floor will build on.

## Why

Two team backgrounds within a small delta-E read as "the same colour" on a 64×64 panel. Concrete: identical navies **NYY≡DET** and **CLE≡MIN** score **0**, near-navy **ATL** scores **8** — all under the ~20 clash threshold — while a real accent clears it comfortably (**DET orange 114**, **silver 71**). That gap is exactly what the next PRs use to pick a club's alternate logo background.

## QC

- 568 tests pass; `omni/core/colors.py` 100% line+branch (one black↔white call exercises both sRGB-linear and both Lab-pivot branches).
- `mypy` clean, `black` clean.
- Verified numerically equal to the legacy implementation on the clash pairs and extremes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
