### PR TITLE
B1: lock the authoritative per-team logo alt palette

### DIFF
--- a/omni/providers/mlb_palette.py
+++ b/omni/providers/mlb_palette.py
@@ -1,0 +1,67 @@
+"""Authoritative per-team logo palette: each club's alternate background colour.
+
+A base logo tile composites the cap insignia on the team's primary colour. When two
+clubs in a matchup have near-identical primaries (the navies NYY/DET, CLE/MIN) they
+read as one indistinct block on a small panel, so one of them renders an *alt* tile
+instead — the same mark on this distinct second brand colour. The freed primary then
+becomes the team's win-probability meter colour (a later feature), which is why the
+alt is a real team colour, not a generic contrasting fill.
+
+Each alt is sourced from the club's official secondary; the value is chosen so the
+mark stays legible against it (every entry clears a `delta_e` floor versus the base
+the tile actually renders on — asserted in `tests/test_mlb_palette.py`). A few are
+deliberate calls: AZ takes the throwback teal, LAD inverts to white (Dodgers carry no
+third colour), MIN takes the 1961–75 vintage blue (a red alt would erase the red "C"
+of the "TC").
+
+`LOGO_BASE_FIX` records the two base tiles whose committed background is simply wrong
+(TEX rendered red rather than the modern royal-blue cap; PIT a warm near-black rather
+than solid black); the asset rebuild applies these. Keyed by StatsAPI team id to join
+`mlb_teams._TEAM_ID_INFO`.
+"""
+
+from __future__ import annotations
+
+from omni.core.colors import RGBColor
+
+__all__ = ["LOGO_ALT_COLOR", "LOGO_BASE_FIX"]
+
+# StatsAPI team id -> the alternate logo background (the distinct second brand colour).
+LOGO_ALT_COLOR: dict[int, RGBColor] = {
+    108: RGBColor(0, 50, 99),  # LAA Angels -> navy
+    109: RGBColor(48, 206, 216),  # AZ D-backs -> teal (throwback)
+    110: RGBColor(0, 0, 0),  # BAL Orioles -> black
+    111: RGBColor(12, 35, 64),  # BOS Red Sox -> navy
+    112: RGBColor(204, 52, 51),  # CHC Cubs -> red
+    113: RGBColor(0, 0, 0),  # CIN Reds -> black
+    114: RGBColor(227, 25, 55),  # CLE Guardians -> red
+    115: RGBColor(196, 206, 212),  # COL Rockies -> silver
+    116: RGBColor(250, 70, 22),  # DET Tigers -> orange
+    117: RGBColor(235, 110, 31),  # HOU Astros -> orange
+    118: RGBColor(189, 155, 96),  # KC Royals -> gold
+    119: RGBColor(255, 255, 255),  # LAD Dodgers -> white (blue-on-white reverse; no third colour)
+    120: RGBColor(20, 34, 90),  # WSH Nationals -> navy
+    121: RGBColor(255, 89, 16),  # NYM Mets -> orange
+    133: RGBColor(239, 178, 30),  # ATH Athletics -> gold
+    134: RGBColor(253, 184, 39),  # PIT Pirates -> gold
+    135: RGBColor(255, 196, 37),  # SD Padres -> gold
+    136: RGBColor(0, 92, 92),  # SEA Mariners -> NW green
+    137: RGBColor(239, 209, 159),  # SF Giants -> cream
+    138: RGBColor(12, 35, 64),  # STL Cardinals -> navy
+    139: RGBColor(143, 188, 230),  # TB Rays -> light blue
+    140: RGBColor(192, 17, 31),  # TEX Rangers -> red
+    141: RGBColor(108, 172, 228),  # TOR Blue Jays -> light blue
+    142: RGBColor(0, 154, 188),  # MIN Twins -> vintage blue (1961-75); red "C"/white "T" stay
+    143: RGBColor(0, 48, 135),  # PHI Phillies -> blue
+    144: RGBColor(206, 17, 65),  # ATL Braves -> scarlet
+    145: RGBColor(196, 206, 212),  # CWS White Sox -> silver
+    146: RGBColor(0, 163, 224),  # MIA Marlins -> Miami blue
+    147: RGBColor(196, 206, 211),  # NYY Yankees -> silver
+    158: RGBColor(255, 199, 44),  # MIL Brewers -> gold
+}
+
+# Base-tile background corrections the asset rebuild applies (committed tile is wrong).
+LOGO_BASE_FIX: dict[int, RGBColor] = {
+    140: RGBColor(0, 50, 120),  # TEX -> royal blue (committed tile is red)
+    134: RGBColor(0, 0, 0),  # PIT -> solid black (committed tile is warm #27251F, two-toned)
+}

--- a/tests/test_mlb_palette.py
+++ b/tests/test_mlb_palette.py
@@ -1,0 +1,39 @@
+"""The authoritative logo alt palette: every team has a distinct, legible alt color."""
+
+from __future__ import annotations
+
+import pytest
+
+from omni.core.colors import RGBColor
+from omni.providers.mlb_palette import LOGO_ALT_COLOR, LOGO_BASE_FIX
+from omni.providers.mlb_teams import _TEAM_ID_INFO
+from omni.renderers.image import LogoImage
+
+# Below this delta_e a mark blurs into its background on a 64px panel; the alt must
+# clear it versus the base the tile actually renders on, or switching to it is futile.
+_FLOOR = 25.0
+
+
+def _base_bg(team_id: int, abbr: str) -> RGBColor:
+    """The colour the base tile renders on — a `LOGO_BASE_FIX` overrides the committed tile."""
+    if team_id in LOGO_BASE_FIX:
+        return LOGO_BASE_FIX[team_id]
+    return LogoImage.from_png(f"assets/logos/mlb/{abbr.lower()}.png", key=abbr.lower()).pixel(0, 0)
+
+
+def test_every_team_has_exactly_one_alt_color() -> None:
+    assert set(LOGO_ALT_COLOR) == set(_TEAM_ID_INFO)  # all 30, no strays
+
+
+@pytest.mark.parametrize("team_id, info", sorted(_TEAM_ID_INFO.items()))
+def test_alt_clears_the_legibility_floor(team_id: int, info: tuple[str, str]) -> None:
+    abbr = info[0]
+    distance = _base_bg(team_id, abbr).delta_e(LOGO_ALT_COLOR[team_id])
+    assert distance >= _FLOOR, f"{abbr}: alt only {distance:.0f} from its base (floor {_FLOOR:.0f})"
+
+
+def test_base_fixes_are_real_corrections() -> None:
+    for team_id, fixed in LOGO_BASE_FIX.items():
+        abbr = _TEAM_ID_INFO[team_id][0]
+        committed = LogoImage.from_png(f"assets/logos/mlb/{abbr.lower()}.png", key=abbr.lower()).pixel(0, 0)
+        assert committed.delta_e(fixed) >= 10  # the override actually changes the tile, not a no-op


### PR DESCRIPTION
## What

The authoritative `{alt color}` per team, plus the two base-tile color corrections. **PR2b of the logo clash work** — the locked palette that drives alt-tile generation (PR2c) and the clash policy (PR2d). No pixels change yet.

## How

- `omni/providers/mlb_palette.py` — `LOGO_ALT_COLOR` (30 teams, keyed by StatsAPI id): each club's distinct second brand color, the background an alt tile uses when a matchup's primaries clash. Doubles as the future win-probability meter color (the freed primary), so each is a real team color.
- `LOGO_BASE_FIX` — the two tiles whose committed background is wrong: **TEX** red → royal blue, **PIT** warm `#27251F` → solid black.

## The sweep that produced it

The existing color data was three disagreeing sources (curated `home`, `accent`, generator tile `bg`) — 16 tiles drifted from their curated primary, 4 accents were generic white, 2 were red-on-red / navy-on-navy. This palette reconciles that into one authoritative table, sourced from official team colors. Deliberate calls confirmed with the owner:
- **AZ** → throwback teal
- **LAD** → white (Dodgers carry no third color, so the alt is the blue-on-white reverse)
- **MIN** → 1961–75 vintage blue `#009ABC` (the "TC" is a red C + white T, so a red alt would erase the C)
- **NYY** → silver, **TEX** base → royal blue

## QC

- 600 tests pass; `mlb_palette.py` 100%.
- A parametrized test asserts **every team's alt clears the delta_e legibility floor (≥25)** versus the base its tile actually renders on (applying the base fixes) — worst real margin is 40. This is the guardrail that a future color tweak can't silently break.
- `mypy` clean, `black` clean.

## Next

PR2c — rebuild the broken/wrong base tiles (TEX, Twins, PIT) and generate the 30 alt tiles from this palette; then a contact-sheet pass for the broader touchups. PR2d — the clash policy + render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
