### PR TITLE
B1.5a: close the provider exception boundary (per-play isolation)

### DIFF
--- a/omni/app/pipeline.py
+++ b/omni/app/pipeline.py
@@ -86,7 +86,8 @@ class PipelineResult:
     finals: tuple[CardId, ...]  # final cards revealed this pass (their post-game delay elapsed)
     held: tuple[LeagueScopedId, ...]  # games whose card is still inside the TV delay (live buffering / final reveal)
     removed: tuple[LeagueScopedId, ...]  # games no longer live whose card was dropped
-    skipped: tuple[str, ...]  # per-game fetch failures (warnings)
+    skipped: tuple[str, ...]  # per-game fetch failures — the game is dropped this pass
+    warnings: tuple[str, ...] = ()  # non-fatal per-play parse drops — the game still shows
 
 
 class LiveBaseballPipeline:
@@ -129,6 +130,7 @@ class LiveBaseballPipeline:
         finals: list[CardId] = []
         held: list[LeagueScopedId] = []
         skipped: list[str] = []
+        warnings: list[str] = []
 
         # Upcoming games card without a feed fetch — there is no score to spoil, so no delay.
         for game in upcoming:
@@ -140,6 +142,7 @@ class LiveBaseballPipeline:
             except ProviderError as exc:
                 skipped.append(f"{game.id.raw}: {exc}")
                 continue
+            warnings.extend(f"{game.id.raw}: {warning}" for warning in feed.warnings)
 
             # Big-play path first, so it runs even when the state is still delay-held.
             big_plays.extend(self._surface_big_plays(game, feed.events, now=now))
@@ -170,6 +173,7 @@ class LiveBaseballPipeline:
             except ProviderError as exc:
                 skipped.append(f"{game.id.raw}: {exc}")
                 continue
+            warnings.extend(f"{game.id.raw}: {warning}" for warning in feed.warnings)
             # Drain any walk-off held from the live ticks: it clears the delay at its own play
             # time, which is at or before the final's first-sight anchor — so it flashes, then
             # the final confirms it. (Surfacing here, before the reveal, keeps the stream alive.)
@@ -192,6 +196,7 @@ class LiveBaseballPipeline:
             held=tuple(sorted(held, key=str)),
             removed=tuple(removed),
             skipped=tuple(skipped),
+            warnings=tuple(warnings),
         )
 
     def _surface_pregame(self, game: TeamGame, *, now: datetime) -> CardId:

--- a/omni/events/baseball.py
+++ b/omni/events/baseball.py
@@ -96,9 +96,11 @@ class LiveBaseballFeed:
 
     `decisions` carries the winning/losing/saving pitchers once the game is final (None
     while it is in progress, a tie, or absent from the feed) — what the final card needs
-    beyond the score.
+    beyond the score. `warnings` lists any plays the parse had to drop (a malformed entry,
+    isolated per-play) so a degraded feed is observable, not silently thinned.
     """
 
     state: BaseballGameState
     events: tuple[BaseballGameEvent, ...] = ()
     decisions: PitchingDecisions | None = None
+    warnings: tuple[str, ...] = ()

--- a/omni/providers/mlb_statsapi.py
+++ b/omni/providers/mlb_statsapi.py
@@ -207,8 +207,8 @@ class MlbStatsApiProvider:
         except Exception as exc:
             raise ProviderError(f"MLB game fetch failed for {game.id.raw}: {exc}") from exc
         state = _parse_game_state(raw)
-        events = _parse_game_events(raw, contest=game, source=self.source, observed_at=now)
-        return LiveBaseballFeed(state=state, events=events, decisions=_parse_decisions(raw))
+        events, warnings = _parse_game_events(raw, contest=game, source=self.source, observed_at=now)
+        return LiveBaseballFeed(state=state, events=events, decisions=_parse_decisions(raw), warnings=warnings)
 
     def fetch_win_probability(self, game: TeamGame) -> WinProbability | None:
         """Fetch one game's live win probability, or None when none is available.
@@ -296,7 +296,9 @@ def _parse_game_state(raw: dict[str, Any]) -> BaseballGameState:
                 third="third" in offense,
             ),
         )
-    except (KeyError, TypeError, ValueError) as exc:
+    except (KeyError, TypeError, ValueError, AttributeError) as exc:
+        # AttributeError covers a null nested object (e.g. `"teams": null` -> None.get(...)),
+        # so a malformed linescore becomes a typed error, never a raw escape.
         raise ProviderError(f"could not parse game state: {exc}") from exc
 
 
@@ -413,17 +415,28 @@ def _parse_one_play(
 
 def _parse_game_events(
     raw: dict[str, Any], *, contest: TeamGame, source: SourceRef, observed_at: datetime
-) -> tuple[BaseballGameEvent, ...]:
-    """Parse a game feed's `liveData.plays.allPlays` into typed, mapped events.
+) -> tuple[tuple[BaseballGameEvent, ...], tuple[str, ...]]:
+    """Parse `liveData.plays.allPlays` into typed events, plus warnings for any it had to drop.
 
-    Robust by design: a feed with no plays yields ``()``; routine and unmapped plays
-    are skipped (see `_parse_one_play`) so one odd entry never sinks the whole parse.
+    Per-play isolation: a feed with no plays yields ``((), ())``; routine and unmapped plays
+    are skipped silently (see `_parse_one_play`), and a *malformed* play — one that raises
+    while parsing — is dropped with a warning instead of sinking the whole parse or escaping
+    the provider boundary. So one odd entry never costs more than that one entry.
     """
     plays = raw.get("liveData", {}).get("plays", {}).get("allPlays", [])
     if not isinstance(plays, list):
-        return ()
-    events = [_parse_one_play(p, contest=contest, source=source, observed_at=observed_at) for p in plays]
-    return tuple(event for event in events if event is not None)
+        return (), ()
+    events: list[BaseballGameEvent] = []
+    warnings: list[str] = []
+    for index, play in enumerate(plays):
+        try:
+            event = _parse_one_play(play, contest=contest, source=source, observed_at=observed_at)
+        except Exception as exc:
+            warnings.append(f"play {index}: {type(exc).__name__}: {exc}")
+            continue
+        if event is not None:
+            events.append(event)
+    return tuple(events), tuple(warnings)
 
 
 def _pitcher_name(person: Any) -> str | None:

--- a/tests/test_app_pipeline.py
+++ b/tests/test_app_pipeline.py
@@ -85,6 +85,7 @@ class _Fetch:
         self.states: dict[str, BaseballGameState] = {}
         self.events: dict[str, tuple[BaseballGameEvent, ...]] = {}
         self.decisions: dict[str, PitchingDecisions] = {}
+        self.warnings: dict[str, tuple[str, ...]] = {}
         self.fail: set[str] = set()
 
     def set(self, raw: str, state: BaseballGameState) -> None:
@@ -100,6 +101,7 @@ class _Fetch:
             state=self.states[game.id.raw],
             events=self.events.get(game.id.raw, ()),
             decisions=self.decisions.get(game.id.raw),
+            warnings=self.warnings.get(game.id.raw, ()),
         )
 
 
@@ -150,7 +152,7 @@ def test_a_non_carding_status_surfaces_nothing() -> None:
     pipe, queue = _setup()
     res = pipe.refresh([_game("g2", GameStatus.POSTPONED)], now=T, fetch_feed=_Fetch())
     assert res == PipelineResult(
-        pregames=(), ingested=(), big_plays=(), no_hitters=(), finals=(), held=(), removed=(), skipped=()
+        pregames=(), ingested=(), big_plays=(), no_hitters=(), finals=(), held=(), removed=(), skipped=(), warnings=()
     )
     assert len(queue) == 0
 
@@ -163,6 +165,29 @@ def test_isolates_per_game_fetch_failures() -> None:
     res = pipe.refresh([_game("g1"), _game("g2")], now=T, fetch_feed=fetch)
     assert any("g1" in warning for warning in res.skipped)
     assert len(res.ingested) == 1 and len(queue) == 1  # g2 still made it through
+
+
+def test_surfaces_per_play_warnings_without_dropping_the_game() -> None:
+    # A malformed play is isolated in the provider; the pipeline surfaces it as a warning, but
+    # the live card still ingests — a per-play drop is not a per-game failure.
+    pipe, queue = _setup(lag=0)  # eligible immediately
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=1, home=2))
+    fetch.warnings["g1"] = ("play 4: ValueError: bad rbi",)
+    res = pipe.refresh([_game("g1")], now=T, fetch_feed=fetch)
+    assert res.warnings == ("g1: play 4: ValueError: bad rbi",)
+    assert len(res.ingested) == 1 and len(queue) == 1  # the game still shows
+    assert res.skipped == ()  # not a dropped-game failure
+
+
+def test_surfaces_per_play_warnings_for_a_final_game() -> None:
+    # The final path collects feed warnings too (off the same per-game fetch).
+    pipe, _queue = _setup(lag=0)  # final reveals as soon as the game is seen final
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=2, home=1))
+    fetch.warnings["g1"] = ("play 7: AttributeError: null about",)
+    res = pipe.refresh([_game("g1", GameStatus.FINAL)], now=T, fetch_feed=fetch)
+    assert res.warnings == ("g1: play 7: AttributeError: null about",)
 
 
 def test_live_card_is_swapped_for_the_final_when_the_game_ends() -> None:

--- a/tests/test_provider_game_events.py
+++ b/tests/test_provider_game_events.py
@@ -49,7 +49,8 @@ def _game() -> TeamGame:
 
 
 def _events() -> tuple[Any, ...]:
-    return _parse_game_events(_feed(), contest=_game(), source=SOURCE, observed_at=NOW)
+    events, _warnings = _parse_game_events(_feed(), contest=_game(), source=SOURCE, observed_at=NOW)
+    return events
 
 
 def _play(**about: Any) -> dict[str, Any]:
@@ -148,12 +149,39 @@ def test_fetch_live_feed_returns_state_and_events_together() -> None:
 
 
 def test_no_plays_yields_no_events() -> None:
-    assert _parse_game_events({"liveData": {"linescore": {}}}, contest=_game(), source=SOURCE, observed_at=NOW) == ()
+    feed: dict[str, Any] = {"liveData": {"linescore": {}}}
+    assert _parse_game_events(feed, contest=_game(), source=SOURCE, observed_at=NOW) == ((), ())
 
 
 def test_non_list_allplays_yields_no_events() -> None:
     feed = {"liveData": {"plays": {"allPlays": "nope"}}}
-    assert _parse_game_events(feed, contest=_game(), source=SOURCE, observed_at=NOW) == ()
+    assert _parse_game_events(feed, contest=_game(), source=SOURCE, observed_at=NOW) == ((), ())
+
+
+@pytest.mark.parametrize(
+    "bad_play, exc_name",
+    [
+        ({"atBatIndex": 6, "result": None, "about": {}, "count": {}}, "AttributeError"),  # null result
+        ({"atBatIndex": 6, "result": {"eventType": "home_run"}, "about": None, "count": {}}, "AttributeError"),  # about
+        ({"atBatIndex": 6, "result": {"eventType": "home_run", "rbi": "lots"}, "about": {}, "count": {}}, "ValueError"),
+    ],
+)
+def test_malformed_play_is_isolated_with_a_warning(bad_play: dict[str, Any], exc_name: str) -> None:
+    # A malformed play must not sink the parse or escape the boundary: drop it, warn, keep the rest.
+    feed = {"liveData": {"plays": {"allPlays": [_play(atBatIndex=5), bad_play]}}}
+    events, warnings = _parse_game_events(feed, contest=_game(), source=SOURCE, observed_at=NOW)
+    assert len(events) == 1 and events[0].event_type is BaseballGameEventType.HOME_RUN  # the good play survived
+    assert len(warnings) == 1 and "play 1" in warnings[0] and exc_name in warnings[0]
+
+
+def test_fetch_live_feed_isolates_a_malformed_play_as_a_feed_warning() -> None:
+    # End to end: one bad play in an otherwise-good feed surfaces as a feed warning, not a crash.
+    raw = _feed()
+    raw["liveData"]["plays"]["allPlays"].append({"atBatIndex": 99, "result": None, "about": {}, "count": {}})
+    provider = MlbStatsApiProvider(MlbTeamRegistry({}), fetch_game=lambda _pk: raw)
+    feed = provider.fetch_live_feed(_game(), now=NOW)
+    assert len(feed.events) == 4  # the four good events still parse
+    assert len(feed.warnings) == 1 and "AttributeError" in feed.warnings[0]
 
 
 def test_unmapped_event_type_is_skipped() -> None:

--- a/tests/test_provider_game_state.py
+++ b/tests/test_provider_game_state.py
@@ -136,3 +136,12 @@ def test_impossible_count_raises_provider_error() -> None:
     feed["liveData"]["linescore"]["outs"] = 5  # past the terminal maximum
     with pytest.raises(ProviderError):
         _parse_game_state(feed)
+
+
+def test_null_nested_object_raises_provider_error() -> None:
+    # A null `linescore` (or `teams`) makes a nested `.get` hit None; that AttributeError is
+    # caught as a typed ProviderError, never escaping the provider boundary as a raw error.
+    with pytest.raises(ProviderError):
+        _parse_game_state({"liveData": {"linescore": None}})
+    with pytest.raises(ProviderError):
+        _parse_game_state({"liveData": {"linescore": {"currentInning": 7, "teams": None}}})


### PR DESCRIPTION
First PR of **B1.5a** — round-2 finding **H2**.

## The hole

A malformed play in `liveData.plays.allPlays` could raise a **raw** `AttributeError`/`ValueError` (e.g. `"result": null` → `None.get("eventType")`). That's not a `ProviderError`, so it slipped past the pipeline's `except ProviderError` (pipeline.py:140,170) and escaped `pipeline.refresh` → `run_once` → **`run_forever` crashed over one bad entry**. `_parse_game_events`' docstring *claimed* robustness it didn't enforce. A second path: `_parse_game_state`'s `except (KeyError, TypeError, ValueError)` missed `AttributeError`, so a `"linescore": null` / `"teams": null` escaped too.

Relying on a loop-level catch-all would be wrong here — one bad play would lose the **entire tick** (every game's update). The fix belongs at the provider boundary.

## The fix

- **Per-play isolation** — `_parse_game_events` wraps each play; a malformed entry is dropped with a typed warning instead of sinking the parse. Returns `(events, warnings)`. Routine/unmapped plays still skip silently.
- **Typed state errors** — `_parse_game_state` also catches `AttributeError`, so a null nested object becomes a `ProviderError`, never a raw escape.
- **Observable, not silent** — `LiveBaseballFeed.warnings` + `PipelineResult.warnings` carry per-play drops up to the tick. A per-play drop is **not** a per-game failure: the live card still ingests. A whole-feed failure is still a `ProviderError` → `PipelineResult.skipped`, isolated per-game as before.

## Verification

- Tests: malformed shapes (null `result`/`about`, non-numeric `rbi`) → isolated + warned; null nested `linescore`/`teams` → `ProviderError`; pipeline surfaces per-play warnings on the live **and** final paths without dropping the game.
- **678 passing, `omni/` 100% line+branch; mypy + black clean.** No rendering touched (no goldens).
- Dogfooded vs **16 real finals** (TEX@MIA, CHC@NYM DH, CLE@CWS, BOS@COL): state + play-by-play parsed, **zero** spurious warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
