### PR TITLE
B1.5a: contextual scoring impact (a walk-off single is a big play)

### DIFF
--- a/omni/cards/factory.py
+++ b/omni/cards/factory.py
@@ -55,9 +55,6 @@ _FINAL_COMPROMISE = (
 # A big play flashes on all three; the small panel drops the play description.
 _BIG_PLAY_PROFILES = frozenset({PanelProfile.SINGLE_64X32, PanelProfile.STACK_64X64, PanelProfile.QUAD_128X64})
 _BIG_PLAY_COMPROMISE = ("single_64x32: headline + score only — the play description is dropped (no room).",)
-# A scoring play takes the screen with a bounded BURST, then yields (never permanent).
-_BIG_PLAY_ATTENTION = AttentionPolicy(mode=AttentionMode.BURST, takeover_for=DurationSeconds(8))
-_BIG_PLAY_PRIORITY = CardPriority(band=DisplayPriority.ALERT, score=0.0)
 # A no-hitter renders natively on all three; the small panel drops the "through N" inning.
 _NO_HITTER_PROFILES = frozenset({PanelProfile.SINGLE_64X32, PanelProfile.STACK_64X64, PanelProfile.QUAD_128X64})
 _NO_HITTER_COMPROMISE = ("single_64x32: headline + team only — the 'through N' inning is dropped (no room).",)
@@ -74,6 +71,26 @@ def _no_hitter_priority(perfect: bool) -> CardPriority:
         score=1.0 if perfect else 0.0,
         reasons=("perfect game",) if perfect else ("no-hitter",),
     )
+
+
+def _big_play_priority(event: BaseballGameEvent) -> CardPriority:
+    """The big-play card's priority from the event's *contextual* importance.
+
+    Carrying the event's band/leverage/reasons (which now reflect what the play did —
+    walk-off, go-ahead, tying — not just its bare type) is what lets a walk-off single
+    outrank a routine RBI in the queue instead of every scoring play looking identical.
+    """
+    return CardPriority(
+        band=event.importance.priority,
+        score=event.importance.leverage,
+        reasons=event.importance.reasons,
+    )
+
+
+def _big_play_attention(band: DisplayPriority) -> AttentionPolicy:
+    """A bounded BURST takeover; a bigger play (an ALERT walk-off / home run) holds a touch longer."""
+    takeover = DurationSeconds(12) if band >= DisplayPriority.ALERT else DurationSeconds(8)
+    return AttentionPolicy(mode=AttentionMode.BURST, takeover_for=takeover)
 
 
 @dataclass(frozen=True, slots=True)
@@ -218,6 +235,7 @@ class CardFactory:
             away_score=away_score,
             home_score=home_score,
         )
+        resolved_priority = priority if priority is not None else _big_play_priority(event)
         key = f"{game.id.raw}:bigplay:{event.id.raw}"
         return ScoreboardCard(
             id=CardId(key),
@@ -229,11 +247,11 @@ class CardFactory:
                 max_display=self.big_play_max_display,
                 expires_at=now + self.big_play_window.as_timedelta(),
             ),
-            priority=priority if priority is not None else _BIG_PLAY_PRIORITY,
+            priority=resolved_priority,
             layout_support=LayoutSupport(profiles=_BIG_PLAY_PROFILES, compromise_notes=_BIG_PLAY_COMPROMISE),
             dedupe_key=DedupeKey(key),
             source_event_ids=(event.id,),
-            attention=_BIG_PLAY_ATTENTION,
+            attention=_big_play_attention(resolved_priority.band),
             payload=payload,
         )
 

--- a/omni/domain/baseball.py
+++ b/omni/domain/baseball.py
@@ -19,8 +19,10 @@ __all__ = [
     "WinProbability",
     "BaseballCount",
     "BaseballBaseState",
+    "BaseballScoringImpact",
     "BaseballGameState",
     "no_hitter_side",
+    "scoring_impact",
 ]
 
 
@@ -168,6 +170,37 @@ class WinProbability:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class BaseballScoringImpact:
+    """How a play changed the score and the game's competitive state.
+
+    Lets a play's drama be judged by what it *did* — drove in the go-ahead run —
+    rather than its bare type (a single). `rbi` is the runs the batter is credited
+    with: the free, reliable signal on a mapped play. A rare run without an RBI (a
+    batter reaching on an error) is not counted as scoring here.
+    """
+
+    rbi: int
+    tying: bool = False  # the play levelled the score
+    go_ahead: bool = False  # the play put the batting side ahead
+    walk_off: bool = False  # a go-ahead run that ended the game (home, bottom of the 9th or later)
+
+    def __post_init__(self) -> None:
+        if self.rbi < 0:
+            raise ValueError("rbi cannot be negative")
+        if self.walk_off and not self.go_ahead:
+            raise ValueError("a walk-off is a kind of go-ahead")
+        if (self.go_ahead or self.tying) and not self.scored:
+            raise ValueError("tying/go-ahead require a run to have scored")
+        if self.go_ahead and self.tying:
+            raise ValueError("a play cannot both tie the game and take the lead")
+
+    @property
+    def scored(self) -> bool:
+        """Whether the play drove in at least one run."""
+        return self.rbi > 0
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class BaseballCount:
     """Balls/strikes/outs at the moment of a play."""
 
@@ -239,3 +272,30 @@ def no_hitter_side(state: BaseballGameState, *, min_inning: int) -> HomeAway | N
     if state.home_hits == 0:
         return HomeAway.AWAY
     return None
+
+
+_WALK_OFF_MIN_INNING = 9  # a game cannot end on a home run before the bottom of the 9th
+
+
+def scoring_impact(
+    *, phase: InningPhase, inning: int, rbi: int, away_score: int | None, home_score: int | None
+) -> BaseballScoringImpact:
+    """Classify a play's scoring impact from its RBI and the resulting score.
+
+    The impact is empty unless the play drove in a run (`rbi > 0`) and the resulting
+    score is known. The batting side is read from the half (`BOTTOM` -> home bats);
+    `tying`/`go_ahead`/`walk_off` follow from the resulting lead and the runs the play is
+    credited with. A walk-off is the home side taking the lead in the bottom of the 9th
+    or later — the run that ends the game.
+    """
+    if rbi <= 0 or away_score is None or home_score is None:
+        return BaseballScoringImpact(rbi=max(rbi, 0))
+    batting_home = phase is InningPhase.BOTTOM
+    lead = (home_score - away_score) if batting_home else (away_score - home_score)
+    go_ahead = 0 < lead <= rbi  # the play moved the batting side from not-ahead to ahead
+    return BaseballScoringImpact(
+        rbi=rbi,
+        tying=away_score == home_score,
+        go_ahead=go_ahead,
+        walk_off=go_ahead and batting_home and inning >= _WALK_OFF_MIN_INNING,
+    )

--- a/omni/events/baseball.py
+++ b/omni/events/baseball.py
@@ -6,7 +6,14 @@ from dataclasses import dataclass
 from enum import Enum
 
 from omni.core.enum import StrEnumMixin
-from omni.domain.baseball import BaseballCount, BaseballGameState, InningPhase, PitchingDecisions, PitchType
+from omni.domain.baseball import (
+    BaseballCount,
+    BaseballGameState,
+    BaseballScoringImpact,
+    InningPhase,
+    PitchingDecisions,
+    PitchType,
+)
 from omni.events.base import GameEvent
 
 __all__ = [
@@ -64,6 +71,10 @@ class BaseballPlayPayload:
     `pitch_type` is the typed `PitchType` of the at-bat's decisive (last) pitch, or None
     when the feed carries no pitch detail — never a raw code string.
 
+    `scoring_impact` classifies what the play did to the score (tying/go-ahead/walk-off),
+    so a card or scorer can judge its drama by context rather than the bare play type; None
+    when not yet computed.
+
     `fielder_sequence` is structured as ints (e.g. ``(9, 6, 4)``), not a string
     like ``"9-6-4-"``; rendering joins it late and avoids dangling delimiters.
     """
@@ -76,6 +87,7 @@ class BaseballPlayPayload:
     away_score: int | None = None
     home_score: int | None = None
     pitch_type: PitchType | None = None
+    scoring_impact: BaseballScoringImpact | None = None
     fielder_sequence: tuple[int, ...] = ()
 
 

--- a/omni/providers/mlb_statsapi.py
+++ b/omni/providers/mlb_statsapi.py
@@ -22,10 +22,12 @@ from omni.domain.baseball import (
     BaseballBaseState,
     BaseballCount,
     BaseballGameState,
+    BaseballScoringImpact,
     InningPhase,
     PitchingDecisions,
     PitchType,
     WinProbability,
+    scoring_impact,
 )
 from omni.domain.contest import TeamGame
 from omni.events.base import EventImportance
@@ -341,16 +343,45 @@ def _safe_count(count: Any) -> BaseballCount | None:
         return None
 
 
-def _event_importance(event_type: BaseballGameEventType) -> EventImportance:
-    """Intrinsic importance of a play from its type alone (context added later)."""
+def _scoring_priority(impact: BaseballScoringImpact) -> tuple[DisplayPriority, float, str] | None:
+    """The band, leverage, and reason a scoring play earns from context, or None if it did not score.
+
+    A scoring play is at least big-play-eligible (HIGH_LEVERAGE) regardless of its bare type;
+    a walk-off is an outright ALERT. Leverage grades the drama within that for ranking.
+    """
+    if not impact.scored:
+        return None
+    if impact.walk_off:
+        return DisplayPriority.ALERT, 1.0, "walk_off"
+    if impact.go_ahead:
+        return DisplayPriority.HIGH_LEVERAGE, 0.8, "go_ahead"
+    if impact.tying:
+        return DisplayPriority.HIGH_LEVERAGE, 0.7, "tying"
+    return DisplayPriority.HIGH_LEVERAGE, 0.4, "scored"
+
+
+def _event_importance(event_type: BaseballGameEventType, impact: BaseballScoringImpact) -> EventImportance:
+    """Importance of a play from its type *and* its scoring context.
+
+    The intrinsic type sets a base band + rarity (a home run is rare on its own); the scoring
+    context can only *raise* the band — so a walk-off single (intrinsically routine) clears the
+    big-play bar, while a non-scoring single stays NORMAL and merely informs the live card.
+    """
     band, rarity = _EVENT_BAND_RARITY.get(event_type, (DisplayPriority.NORMAL, 0.1))
+    leverage = 0.0
+    reasons: tuple[str, ...] = (event_type.value,)
+    scoring = _scoring_priority(impact)
+    if scoring is not None:
+        scoring_band, leverage, reason = scoring
+        band = max(band, scoring_band)
+        reasons = reasons + (reason,)
     return EventImportance(
         priority=band,
         urgency=_BAND_URGENCY.get(band, UpdateUrgency.NORMAL),
-        leverage=0.0,
+        leverage=leverage,
         rarity=rarity,
         favorite_relevance=0.0,
-        reasons=(event_type.value,),
+        reasons=reasons,
     )
 
 
@@ -391,15 +422,22 @@ def _parse_one_play(
         return None  # no stable lineage key — cannot dedupe across polls; skip
     # Anchor the TV-delay to when the play happened; fall back to receipt time.
     source_time = _parse_iso(about.get("endTime")) or _parse_iso(about.get("startTime")) or observed_at
+    inning = int(about.get("inning") or 1)
+    phase = _HALF_INNING_PHASE.get(str(about.get("halfInning", "")), InningPhase.TOP)
+    rbi = int(result.get("rbi") or 0)
+    away_score = _safe_int(result.get("awayScore"))
+    home_score = _safe_int(result.get("homeScore"))
+    impact = scoring_impact(phase=phase, inning=inning, rbi=rbi, away_score=away_score, home_score=home_score)
     payload = BaseballPlayPayload(
-        inning=int(about.get("inning") or 1),
-        phase=_HALF_INNING_PHASE.get(str(about.get("halfInning", "")), InningPhase.TOP),
+        inning=inning,
+        phase=phase,
         description=str(result.get("description", "")),
         count=_safe_count(play.get("count")),
-        rbi=int(result.get("rbi") or 0),
-        away_score=_safe_int(result.get("awayScore")),
-        home_score=_safe_int(result.get("homeScore")),
+        rbi=rbi,
+        away_score=away_score,
+        home_score=home_score,
         pitch_type=_decisive_pitch_type(play),
+        scoring_impact=impact,
     )
     return BaseballGameEvent(
         id=LeagueScopedId(contest.league, source, f"{contest.id.raw}:ab:{at_bat_index}"),
@@ -408,7 +446,7 @@ def _parse_one_play(
         source=source,
         source_time=source_time,
         observed_at=observed_at,
-        importance=_event_importance(event_type),
+        importance=_event_importance(event_type, impact),
         payload=payload,
     )
 

--- a/tests/test_domain_baseball.py
+++ b/tests/test_domain_baseball.py
@@ -9,11 +9,13 @@ from omni.domain.baseball import (
     BaseballBaseState,
     BaseballCount,
     BaseballGameState,
+    BaseballScoringImpact,
     InningPhase,
     PitchingDecisions,
     PitchType,
     WinProbability,
     no_hitter_side,
+    scoring_impact,
 )
 
 
@@ -139,3 +141,58 @@ def test_win_probability_rejects_out_of_range_percentages() -> None:
         WinProbability(home=120.0, away=0.0)
     with pytest.raises(ValueError):
         WinProbability(home=-1.0, away=101.0)
+
+
+# --- scoring impact -------------------------------------------------------------
+
+
+def test_scoring_impact_empty_without_a_run() -> None:
+    impact = scoring_impact(phase=InningPhase.TOP, inning=3, rbi=0, away_score=2, home_score=2)
+    assert not impact.scored and impact.rbi == 0
+    assert not (impact.tying or impact.go_ahead or impact.walk_off)
+
+
+def test_scoring_impact_records_rbi_even_without_a_known_score() -> None:
+    # A run scored (rbi>0) but the resulting score is absent: count the run, classify nothing.
+    impact = scoring_impact(phase=InningPhase.TOP, inning=3, rbi=2, away_score=None, home_score=None)
+    assert impact.scored and impact.rbi == 2
+    assert not (impact.tying or impact.go_ahead or impact.walk_off)
+
+
+def test_scoring_impact_detects_a_tying_run() -> None:
+    impact = scoring_impact(phase=InningPhase.TOP, inning=8, rbi=1, away_score=3, home_score=3)
+    assert impact.tying and not impact.go_ahead and not impact.walk_off
+
+
+def test_scoring_impact_detects_a_go_ahead_run_for_either_side() -> None:
+    away = scoring_impact(phase=InningPhase.TOP, inning=7, rbi=2, away_score=5, home_score=4)
+    assert away.go_ahead and not away.walk_off  # away leads by 1 (<= 2 rbi) -> go-ahead
+    home = scoring_impact(phase=InningPhase.BOTTOM, inning=7, rbi=1, away_score=4, home_score=5)
+    assert home.go_ahead and not home.walk_off  # not the 9th yet -> not a walk-off
+
+
+def test_scoring_impact_insurance_run_is_not_go_ahead() -> None:
+    # Home already led 5-1; a 1-RBI single makes it 6-1 — scored, but not tying/go-ahead.
+    impact = scoring_impact(phase=InningPhase.BOTTOM, inning=6, rbi=1, away_score=1, home_score=6)
+    assert impact.scored and not impact.go_ahead and not impact.tying
+
+
+def test_scoring_impact_detects_a_walk_off() -> None:
+    ninth = scoring_impact(phase=InningPhase.BOTTOM, inning=9, rbi=1, away_score=3, home_score=4)
+    assert ninth.walk_off and ninth.go_ahead
+    extras = scoring_impact(phase=InningPhase.BOTTOM, inning=11, rbi=1, away_score=2, home_score=3)
+    assert extras.walk_off
+
+
+def test_scoring_impact_rejects_contradictions() -> None:
+    assert BaseballScoringImpact(rbi=1, tying=True).scored  # a valid tying run
+    with pytest.raises(ValueError):
+        BaseballScoringImpact(rbi=-1)
+    with pytest.raises(ValueError):
+        BaseballScoringImpact(rbi=1, walk_off=True)  # a walk-off must be a go-ahead
+    with pytest.raises(ValueError):
+        BaseballScoringImpact(rbi=0, go_ahead=True)  # go-ahead needs a run
+    with pytest.raises(ValueError):
+        BaseballScoringImpact(rbi=0, tying=True)  # tying needs a run
+    with pytest.raises(ValueError):
+        BaseballScoringImpact(rbi=1, tying=True, go_ahead=True)  # cannot both tie and lead

--- a/tests/test_provider_game_events.py
+++ b/tests/test_provider_game_events.py
@@ -11,7 +11,7 @@ import pytest
 
 from omni.core.enum import DisplayPriority, GameStatus, League
 from omni.core.ids import LeagueScopedId, SourceRef
-from omni.domain.baseball import InningPhase, PitchType
+from omni.domain.baseball import BaseballScoringImpact, InningPhase, PitchType, scoring_impact
 from omni.domain.contest import TeamGame
 from omni.events.baseball import BaseballGameEventType
 from omni.providers.mlb_statsapi import (
@@ -138,7 +138,7 @@ def test_importance_ranks_home_run_above_single() -> None:
     single = events[BaseballGameEventType.SINGLE].importance
     assert hr.priority is DisplayPriority.ALERT
     assert hr.combined_score() > single.combined_score()
-    assert hr.reasons == ("home_run",)  # explainable, not a bare float
+    assert hr.reasons == ("home_run", "go_ahead")  # type + scoring context, not a bare float
 
 
 def test_fetch_live_feed_returns_state_and_events_together() -> None:
@@ -260,5 +260,43 @@ def test_safe_count_handles_missing_and_bad() -> None:
 
 def test_event_importance_default_for_untabled_type() -> None:
     # A mapped type always has a table entry; an off-table type takes the modest default.
-    imp = _event_importance(BaseballGameEventType.PITCH)
+    imp = _event_importance(BaseballGameEventType.PITCH, BaseballScoringImpact(rbi=0))
     assert imp.priority is DisplayPriority.NORMAL and imp.rarity == pytest.approx(0.1)
+
+
+def test_scoring_context_lifts_a_walk_off_single_to_alert() -> None:
+    # The headline H3 fix: a walk-off single is intrinsically NORMAL but, in context, an ALERT
+    # that clears the big-play bar — so it flashes like the dramatic play it is.
+    walk_off = scoring_impact(phase=InningPhase.BOTTOM, inning=9, rbi=1, away_score=3, home_score=4)
+    imp = _event_importance(BaseballGameEventType.SINGLE, walk_off)
+    assert imp.priority is DisplayPriority.ALERT and "walk_off" in imp.reasons and imp.leverage == 1.0
+
+
+def test_scoring_context_makes_a_go_ahead_single_eligible() -> None:
+    # A go-ahead RBI single (intrinsically NORMAL) reaches the HIGH_LEVERAGE big-play floor.
+    go_ahead = scoring_impact(phase=InningPhase.TOP, inning=7, rbi=1, away_score=4, home_score=3)
+    imp = _event_importance(BaseballGameEventType.SINGLE, go_ahead)
+    assert imp.priority is DisplayPriority.HIGH_LEVERAGE and "go_ahead" in imp.reasons
+
+
+def test_a_non_scoring_single_stays_normal() -> None:
+    # No RBI, no context: a routine single informs the live card but never takes over.
+    routine = scoring_impact(phase=InningPhase.TOP, inning=2, rbi=0, away_score=0, home_score=0)
+    imp = _event_importance(BaseballGameEventType.SINGLE, routine)
+    assert imp.priority is DisplayPriority.NORMAL and imp.reasons == ("single",)
+
+
+def test_tying_and_plain_scoring_runs_clear_the_big_play_floor() -> None:
+    tying = scoring_impact(phase=InningPhase.TOP, inning=8, rbi=1, away_score=3, home_score=3)
+    tying_imp = _event_importance(BaseballGameEventType.SINGLE, tying)
+    assert tying_imp.priority is DisplayPriority.HIGH_LEVERAGE and "tying" in tying_imp.reasons
+    plain = scoring_impact(phase=InningPhase.BOTTOM, inning=6, rbi=1, away_score=1, home_score=6)
+    plain_imp = _event_importance(BaseballGameEventType.SINGLE, plain)
+    assert plain_imp.priority is DisplayPriority.HIGH_LEVERAGE and "scored" in plain_imp.reasons
+
+
+def test_parsed_play_carries_its_scoring_impact() -> None:
+    # The impact rides on the payload (for a card/badge later), computed once at parse.
+    hr = next(e for e in _events() if e.event_type is BaseballGameEventType.HOME_RUN)
+    impact = hr.payload.scoring_impact
+    assert impact is not None and impact.rbi == 2 and impact.go_ahead and not impact.walk_off


### PR DESCRIPTION
Second PR of **B1.5a** — round-2 finding **H3**.

## The bug

Big-play eligibility came from the play's *bare type*. `_event_importance` mapped `SINGLE`/`WALK`/`SAC_FLY`/`HIT_BY_PITCH` → `NORMAL`, below the pipeline's `HIGH_LEVERAGE` big-play floor (pipeline.py:218). So the single most dramatic play in baseball — **a walk-off single** — never flashed, while a meaningless solo home run in a 10-2 blowout always did.

## The fix — judge a play by what it *did*

- **`BaseballScoringImpact`** (domain) + a pure **`scoring_impact()`**: from the play's RBI and resulting score, classify **tying / go-ahead / walk-off** (a go-ahead run by the home side in the bottom of the 9th or later). Rides on the play payload, computed once at parse.
- **`_event_importance(event_type, impact)`**: the intrinsic type still sets a base band + rarity, but scoring context can only *raise* it — a scoring play is at least `HIGH_LEVERAGE` (eligible), a walk-off an outright `ALERT`. A non-scoring single stays `NORMAL`. Leverage grades the drama for ranking (walk-off 1.0 > go-ahead 0.8 > tying 0.7 > plain RBI 0.4).
- **No pipeline change** — scoring plays clear the existing gate via their elevated importance.
- The **big-play card's priority + attention now follow that contextual importance** (a walk-off `ALERT` holds the screen a touch longer and outranks a routine RBI), replacing the fixed `ALERT`/`BURST`.

## Verification

- Tests: `scoring_impact` across tying / go-ahead (either side) / walk-off (9th + extras) / insurance / no-run / unknown-score + the impact invariants; the contextual bands per tier; the payload carries the impact.
- **690 passing, `omni/` 100% line+branch; mypy + black clean.** No rendering touched (no goldens).
- Dogfooded vs **16 real finals**: **65 small scoring plays** (go-ahead/tying singles, an RBI walk, a sac fly) lifted past the gate — every one `NORMAL` before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
