### PR TITLE
B1.5a: correct no-hitter/perfect-game progress (side-specific completed innings)

### DIFF
--- a/omni/app/pipeline.py
+++ b/omni/app/pipeline.py
@@ -47,7 +47,7 @@ from omni.cards.factory import CardFactory
 from omni.core.enum import DisplayPriority, GameStatus
 from omni.core.ids import LeagueScopedId
 from omni.core.observation import Observation
-from omni.domain.baseball import BaseballGameState, PitchingDecisions, no_hitter_side
+from omni.domain.baseball import BaseballGameState, PitchingDecisions, pitching_feat_progress
 from omni.domain.contest import TeamGame
 from omni.events.baseball import BaseballGameEvent, LiveBaseballFeed
 from omni.providers.base import ProviderError
@@ -71,8 +71,9 @@ _UPCOMING_STATUSES = frozenset({GameStatus.SCHEDULED, GameStatus.PREGAME})
 # a walk) the play informs the live card but is not worth a takeover. HR/triple/DP/TP clear it.
 _BIG_PLAY_MIN_BAND = DisplayPriority.HIGH_LEVERAGE
 
-# A no-hitter only becomes news once the game is this deep — earlier hitless innings are routine.
-_NO_HITTER_MIN_INNING = 6
+# A no-hitter only becomes news once the pitching side has *finished* this many hitless innings;
+# earlier hitless innings are routine. Counted per side so it never triggers a half-inning early.
+_NO_HITTER_MIN_COMPLETED_INNINGS = 6
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -239,15 +240,22 @@ class LiveBaseballPipeline:
         return surfaced
 
     def _surface_no_hitter(self, game: TeamGame, state: BaseballGameState, *, now: datetime) -> CardId | None:
-        """Surface (or refresh) an active no-hitter card, or remove it once the bid is broken."""
-        side = no_hitter_side(state, min_inning=_NO_HITTER_MIN_INNING)
-        if side is None:
+        """Surface (or refresh) an active no-hitter / perfect-game card, or remove it once broken.
+
+        The depth shown is the pitching side's *finished* innings (not the raw current inning),
+        and a confirmed clean sheet promotes the card to a perfect game — both off the same
+        delay-safe state, so the feat is revealed and un-revealed only as the broadcast would show.
+        """
+        feat = pitching_feat_progress(state, min_completed_innings=_NO_HITTER_MIN_COMPLETED_INNINGS)
+        if feat is None:
             # No (longer) a bid — drop the card if this game had one.
             stale = self._no_hitter_keys.pop(game.id, None)
             if stale is not None:
                 self._queue.remove(stale)
             return None
-        card = self._factory.no_hitter(game, pitching_side=side, through_inning=state.inning, now=now)
+        card = self._factory.no_hitter(
+            game, pitching_side=feat.side, through_inning=feat.completed_innings, perfect=feat.perfect, now=now
+        )
         self._queue.ingest(card)
         self._no_hitter_keys[game.id] = card.dedupe_key.raw
         return card.id

--- a/omni/cards/baseball.py
+++ b/omni/cards/baseball.py
@@ -132,9 +132,10 @@ class NoHitterCardPayload:
     The feat belongs to the *defending* team, so `pitching_side` says which side of the
     contest that is and the renderer names the team from the contest (never a stored
     string). `perfect` distinguishes a perfect game (no baserunner has reached at all)
-    from a plain no-hitter; `through_inning` is how deep it has carried. Unlike a big
-    play this is a standing condition, not a one-shot event — it carries no lineage and
-    lives (recurring) until it is broken.
+    from a plain no-hitter; `through_inning` is how deep it has carried — the pitching
+    side's *completed* innings, so 6 means through six full innings, not the current
+    inning number. Unlike a big play this is a standing condition, not a one-shot event —
+    it carries no lineage and lives (recurring) until it is broken.
     """
 
     pitching_side: HomeAway

--- a/omni/domain/baseball.py
+++ b/omni/domain/baseball.py
@@ -21,7 +21,9 @@ __all__ = [
     "BaseballBaseState",
     "BaseballScoringImpact",
     "BaseballGameState",
-    "no_hitter_side",
+    "PitchingFeatKind",
+    "PitchingFeatProgress",
+    "pitching_feat_progress",
     "scoring_impact",
 ]
 
@@ -245,6 +247,12 @@ class BaseballGameState:
     bases: BaseballBaseState
     away_hits: int = 0
     home_hits: int = 0
+    # Whether each side has reached base at all this game: True (a baserunner is confirmed),
+    # False (confirmed none — a perfect game in the making), or None (the feed does not say).
+    # It only matters for a side being no-hit, where it is what separates a perfect game from
+    # a plain no-hitter; None keeps the safe default of never claiming perfection unproven.
+    away_reached_base: bool | None = None
+    home_reached_base: bool | None = None
 
     def __post_init__(self) -> None:
         if self.away_score < 0 or self.home_score < 0:
@@ -255,23 +263,89 @@ class BaseballGameState:
             raise ValueError("inning must be >= 1")
 
 
-def no_hitter_side(state: BaseballGameState, *, min_inning: int) -> HomeAway | None:
-    """The side throwing an active no-hitter bid in `state`, or None.
+class PitchingFeatKind(StrEnumMixin, str, Enum):
+    """A no-hit pitching feat in progress: a plain no-hitter, or a perfect game.
 
-    A bid only counts once the game has reached `min_inning` — early hitless innings
-    are routine, not news — and the batting side still has zero hits: a hitless away
-    team means the home pitching staff is throwing the no-hitter, and vice versa. The
-    bid persists across both halves of an inning (it is about hits allowed, not who is
-    batting now) until a hit breaks it. If both sides are hitless (a rare double
-    no-hitter) the away team's drought is the one reported.
+    A perfect game is a no-hitter with no baserunner allowed at all, so it strictly
+    outranks one — the same card, a stronger headline.
     """
-    if state.inning < min_inning:
-        return None
+
+    NO_HITTER = "no_hitter"
+    PERFECT_GAME = "perfect_game"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PitchingFeatProgress:
+    """How far a no-hit pitching feat has carried, and which side is throwing it.
+
+    `side` is the *pitching* (defending) side — the away team being hitless means the home
+    staff is throwing it. `completed_innings` counts that side's *finished* defensive half-
+    innings, so a bid in the top of the 6th is "through 5", not 6; it is what a card shows as
+    "through N". `kind` distinguishes a perfect game from a plain no-hitter.
+    """
+
+    side: HomeAway
+    kind: PitchingFeatKind
+    completed_innings: int
+
+    def __post_init__(self) -> None:
+        if self.completed_innings < 1:
+            raise ValueError("a pitching feat must have at least one completed inning")
+
+    @property
+    def perfect(self) -> bool:
+        """True for a perfect game (no baserunner allowed), False for a plain no-hitter."""
+        return self.kind is PitchingFeatKind.PERFECT_GAME
+
+
+def _no_hit_pitching_side(state: BaseballGameState) -> HomeAway | None:
+    """The side throwing a no-hit bid (the hitless side's opponent), or None if both have hit.
+
+    A hitless away team means the home staff is throwing it, and vice versa. The bid is about
+    hits *allowed*, so it persists across both halves of an inning until a hit breaks it. If
+    both sides are hitless — a rare double no-hitter — the home side is reported: it pitches the
+    top of each inning, so it has always finished at least as many innings as the away side,
+    making it the deeper (or equal) of the two bids.
+    """
     if state.away_hits == 0:
         return HomeAway.HOME
     if state.home_hits == 0:
         return HomeAway.AWAY
     return None
+
+
+def _completed_defensive_innings(*, pitching: HomeAway, inning: int, phase: InningPhase) -> int:
+    """How many defensive half-innings `pitching` has *finished* at `inning`/`phase`.
+
+    The home side pitches the top of each inning, the away side the bottom; a half-inning
+    counts as finished only once play has moved past it. So in the top of the 6th the home
+    pitcher has finished 5 (not 6), and the away pitcher finishes its 6th only at the End break.
+    """
+    if pitching is HomeAway.HOME:
+        # The top is still in progress during TOP (one fewer finished); past it by Middle/Bottom/End.
+        return inning - 1 if phase is InningPhase.TOP else inning
+    # The bottom is finished only at the End break; before that the away pitcher is mid- or pre-inning.
+    return inning if phase is InningPhase.END else inning - 1
+
+
+def pitching_feat_progress(state: BaseballGameState, *, min_completed_innings: int) -> PitchingFeatProgress | None:
+    """The no-hit feat `state` shows once it is deep enough to be news, or None.
+
+    A bid is surfaced only once the pitching side has *finished* `min_completed_innings`
+    hitless innings — counted per side, so the bid can't surface a half-inning early. It is a
+    perfect game only when the batting side is *confirmed* not to have reached base
+    (`reached_base is False`); an unknown reached-base state (None) stays a plain no-hitter, so
+    the rarer claim is never made without evidence.
+    """
+    pitching = _no_hit_pitching_side(state)
+    if pitching is None:
+        return None
+    completed = _completed_defensive_innings(pitching=pitching, inning=state.inning, phase=state.phase)
+    if completed < min_completed_innings:
+        return None
+    reached = state.away_reached_base if pitching is HomeAway.HOME else state.home_reached_base
+    kind = PitchingFeatKind.PERFECT_GAME if reached is False else PitchingFeatKind.NO_HITTER
+    return PitchingFeatProgress(side=pitching, kind=kind, completed_innings=completed)
 
 
 _WALK_OFF_MIN_INNING = 9  # a game cannot end on a home run before the bottom of the 9th

--- a/omni/providers/mlb_statsapi.py
+++ b/omni/providers/mlb_statsapi.py
@@ -267,6 +267,38 @@ def _phase_from_inning_state(inning_state: str) -> InningPhase:
     return _INNING_STATE_PHASE.get(inning_state, InningPhase.TOP)
 
 
+def _batting_walks_hbp(raw: dict[str, Any], side: str) -> int | None:
+    """Walks + hit-by-pitch for `side` from the boxscore batting line, or None if absent.
+
+    These are the on-base events a no-hit line still allows — a walk is the classic blemish on a
+    no-hitter — and the linescore omits them, so they come from the boxscore. ``or {}`` tolerates
+    a null node at any level; None (no batting block) means the count is *unknown*, not zero.
+    """
+    boxscore = (raw.get("liveData") or {}).get("boxscore") or {}
+    batting = ((boxscore.get("teams") or {}).get(side) or {}).get("teamStats") or {}
+    line = batting.get("batting")
+    if not isinstance(line, dict):
+        return None
+    return int(line.get("baseOnBalls", 0) or 0) + int(line.get("hitByPitch", 0) or 0)
+
+
+def _reached_base(raw: dict[str, Any], *, side: str, hits: int, fielding_errors: int) -> bool | None:
+    """Whether `side` has reached base at all this game: True / False / None (unknown).
+
+    A hit, or an error by the defense, is a definite baserunner. Otherwise the call needs the
+    boxscore walks/HBP: present -> a clean sheet (False) unless a walk/HBP put a man on; absent ->
+    None, so a perfect game is never claimed without the data to rule a baserunner out. Counting a
+    fielding error as a baserunner can only ever err toward a plain no-hitter (a muffed foul that
+    let no one reach), never toward a false perfect game.
+    """
+    if hits > 0 or fielding_errors > 0:
+        return True
+    walks_hbp = _batting_walks_hbp(raw, side)
+    if walks_hbp is None:
+        return None
+    return walks_hbp > 0
+
+
 def _parse_game_state(raw: dict[str, Any]) -> BaseballGameState:
     """Parse a StatsAPI game feed's linescore into typed `BaseballGameState`.
 
@@ -280,11 +312,21 @@ def _parse_game_state(raw: dict[str, Any]) -> BaseballGameState:
             raise ValueError("game feed has no current inning (not live yet?)")
         teams = line.get("teams", {})
         offense = line.get("offense", {})
+        away_team = teams.get("away", {})
+        home_team = teams.get("home", {})
+        away_hits = int(away_team.get("hits", 0) or 0)
+        home_hits = int(home_team.get("hits", 0) or 0)
+        away_errors = int(away_team.get("errors", 0) or 0)
+        home_errors = int(home_team.get("errors", 0) or 0)
         return BaseballGameState(
-            away_score=int(teams.get("away", {}).get("runs", 0) or 0),
-            home_score=int(teams.get("home", {}).get("runs", 0) or 0),
-            away_hits=int(teams.get("away", {}).get("hits", 0) or 0),
-            home_hits=int(teams.get("home", {}).get("hits", 0) or 0),
+            away_score=int(away_team.get("runs", 0) or 0),
+            home_score=int(home_team.get("runs", 0) or 0),
+            away_hits=away_hits,
+            home_hits=home_hits,
+            # A side's reached-base read needs the *fielding* side's errors: an away batter
+            # reaching on error is charged to the home defense, and vice versa.
+            away_reached_base=_reached_base(raw, side="away", hits=away_hits, fielding_errors=home_errors),
+            home_reached_base=_reached_base(raw, side="home", hits=home_hits, fielding_errors=away_errors),
             inning=inning,
             phase=_phase_from_inning_state(str(line.get("inningState", "Top"))),
             count=BaseballCount(
@@ -527,12 +569,15 @@ def _default_fetch_schedule(game_date: date, sport_ids: str) -> list[dict[str, A
     return result
 
 
-# StatsAPI `fields` is a hierarchical key-name whitelist. The first group keeps the
-# linescore (-> BaseballGameState); the second keeps play-by-play (-> events). A name
-# must be listed for its nested object to survive, so omitting one silently drops that
-# data — keep this in sync with what `_parse_game_state` / `_parse_game_events` read.
+# StatsAPI `fields` is a hierarchical key-name whitelist. The first group keeps the linescore
+# and a slice of the boxscore (-> BaseballGameState, including reached-base); the second keeps
+# play-by-play (-> events). A name must be listed for its nested object to survive, so omitting
+# one silently drops that data — keep this in sync with what `_parse_game_state` /
+# `_parse_game_events` read.
 _GAME_FIELDS = (
-    "liveData,linescore,teams,home,away,runs,hits,currentInning,inningState,balls,strikes,outs,offense,first,second,third,"
+    "liveData,linescore,teams,home,away,runs,hits,errors,currentInning,inningState,balls,strikes,outs,"
+    "offense,first,second,third,"
+    "boxscore,teamStats,batting,baseOnBalls,hitByPitch,"  # per-side walks/HBP -> perfect-game detection
     "plays,allPlays,result,eventType,description,rbi,awayScore,homeScore,about,inning,halfInning,atBatIndex,"
     "endTime,startTime,count,playEvents,isPitch,details,type,code,decisions,winner,loser,save,fullName"
 )

--- a/tests/test_app_pipeline.py
+++ b/tests/test_app_pipeline.py
@@ -40,16 +40,28 @@ def _game(raw: str, status: GameStatus = GameStatus.LIVE) -> TeamGame:
     )
 
 
-def _state(away: int = 0, home: int = 0, inning: int = 3, away_hits: int = 5, home_hits: int = 5) -> BaseballGameState:
+def _state(
+    away: int = 0,
+    home: int = 0,
+    inning: int = 3,
+    away_hits: int = 5,
+    home_hits: int = 5,
+    *,
+    phase: InningPhase = InningPhase.TOP,
+    away_reached_base: bool | None = None,
+    home_reached_base: bool | None = None,
+) -> BaseballGameState:
     return BaseballGameState(
         away_score=away,
         home_score=home,
         inning=inning,
-        phase=InningPhase.TOP,
+        phase=phase,
         count=BaseballCount(balls=0, strikes=0, outs=0),
         bases=BaseballBaseState(),
         away_hits=away_hits,
         home_hits=home_hits,
+        away_reached_base=away_reached_base,
+        home_reached_base=home_reached_base,
     )
 
 
@@ -376,6 +388,27 @@ def test_no_hitter_card_not_surfaced_before_the_min_inning() -> None:
     fetch.set("g1", _state(inning=3, away_hits=0))  # hitless, but only the 3rd — routine
     res = pipe.refresh([_game("g1")], now=T, fetch_feed=fetch)
     assert res.no_hitters == () and len(queue) == 1
+
+
+def test_no_hitter_card_not_surfaced_at_the_top_of_the_sixth() -> None:
+    # In the top of the 6th the pitching side has finished only five innings — not yet news.
+    pipe, queue = _setup(lag=0)
+    fetch = _Fetch()
+    fetch.set("g1", _state(inning=6, phase=InningPhase.TOP, away_hits=0))
+    res = pipe.refresh([_game("g1")], now=T, fetch_feed=fetch)
+    assert res.no_hitters == () and len(queue) == 1  # just the live card — the bid is "through 5"
+
+
+def test_perfect_game_surfaces_with_the_perfect_flag_and_finished_innings() -> None:
+    pipe, queue = _setup(lag=0)
+    fetch = _Fetch()
+    # Away hitless in the top of the 7th (home has finished six) with a confirmed clean sheet.
+    fetch.set("g1", _state(inning=7, phase=InningPhase.TOP, away_hits=0, away_reached_base=False))
+    res = pipe.refresh([_game("g1")], now=T, fetch_feed=fetch)
+    assert [c.raw for c in res.no_hitters] == ["g1:nohitter"]
+    card = queue.next_card(T, QUAD)
+    assert card is not None and card.dedupe_key.raw == "g1:nohitter"
+    assert card.payload.perfect is True and card.payload.through_inning == 6  # finished innings, not current
 
 
 def test_no_hitter_card_dropped_when_its_game_leaves() -> None:

--- a/tests/test_domain_baseball.py
+++ b/tests/test_domain_baseball.py
@@ -12,9 +12,11 @@ from omni.domain.baseball import (
     BaseballScoringImpact,
     InningPhase,
     PitchingDecisions,
+    PitchingFeatKind,
+    PitchingFeatProgress,
     PitchType,
     WinProbability,
-    no_hitter_side,
+    pitching_feat_progress,
     scoring_impact,
 )
 
@@ -71,22 +73,96 @@ def test_game_state_holds_hits_and_rejects_negative() -> None:
         _state(home_hits=-1)
 
 
-def test_no_hitter_side_names_the_pitching_team() -> None:
+def test_pitching_feat_names_the_pitching_side() -> None:
     # The hitless batting side names who is throwing it: away hitless -> home, and vice versa.
-    assert no_hitter_side(_state(inning=7, away_hits=0, home_hits=3), min_inning=6) is HomeAway.HOME
-    assert no_hitter_side(_state(inning=7, away_hits=3, home_hits=0), min_inning=6) is HomeAway.AWAY
+    home = pitching_feat_progress(
+        _state(inning=7, phase=InningPhase.TOP, away_hits=0, home_hits=3), min_completed_innings=6
+    )
+    assert home is not None and home.side is HomeAway.HOME
+    # The away side pitches the bottom, so it finishes its 6th only at the End break.
+    away = pitching_feat_progress(
+        _state(inning=7, phase=InningPhase.END, away_hits=3, home_hits=0), min_completed_innings=6
+    )
+    assert away is not None and away.side is HomeAway.AWAY
 
 
-def test_no_hitter_side_none_when_both_sides_have_hits() -> None:
-    assert no_hitter_side(_state(inning=8, away_hits=2, home_hits=1), min_inning=6) is None
+@pytest.mark.parametrize(
+    "phase, expected",
+    [
+        (InningPhase.TOP, 6),  # top of the 7th in progress -> only six finished (the off-by-one)
+        (InningPhase.MIDDLE, 7),  # the top is done
+        (InningPhase.BOTTOM, 7),
+        (InningPhase.END, 7),
+    ],
+)
+def test_home_feat_counts_finished_tops(phase: InningPhase, expected: int) -> None:
+    feat = pitching_feat_progress(_state(inning=7, phase=phase, away_hits=0, home_hits=3), min_completed_innings=1)
+    assert feat is not None and feat.side is HomeAway.HOME and feat.completed_innings == expected
 
 
-def test_no_hitter_side_reports_the_away_drought_in_a_double_no_hitter() -> None:
-    assert no_hitter_side(_state(inning=7, away_hits=0, home_hits=0), min_inning=6) is HomeAway.HOME
+@pytest.mark.parametrize(
+    "phase, expected",
+    [
+        (InningPhase.TOP, 6),
+        (InningPhase.MIDDLE, 6),
+        (InningPhase.BOTTOM, 6),  # bottom of the 7th in progress -> still six finished
+        (InningPhase.END, 7),  # the bottom is done
+    ],
+)
+def test_away_feat_counts_finished_bottoms(phase: InningPhase, expected: int) -> None:
+    feat = pitching_feat_progress(_state(inning=7, phase=phase, away_hits=3, home_hits=0), min_completed_innings=1)
+    assert feat is not None and feat.side is HomeAway.AWAY and feat.completed_innings == expected
 
 
-def test_no_hitter_side_suppressed_before_the_threshold() -> None:
-    assert no_hitter_side(_state(inning=5, away_hits=0, home_hits=4), min_inning=6) is None
+def test_pitching_feat_not_news_until_min_completed_innings() -> None:
+    # The top of the 6th is only five finished innings — the bug that surfaced it a half-inning early.
+    assert pitching_feat_progress(_state(inning=6, phase=InningPhase.TOP, away_hits=0), min_completed_innings=6) is None
+    # The same top *done* (Middle) is the sixth finished inning — now it is news.
+    feat = pitching_feat_progress(_state(inning=6, phase=InningPhase.MIDDLE, away_hits=0), min_completed_innings=6)
+    assert feat is not None and feat.completed_innings == 6
+
+
+def test_pitching_feat_none_when_both_sides_have_hits() -> None:
+    assert pitching_feat_progress(_state(inning=8, away_hits=2, home_hits=1), min_completed_innings=6) is None
+
+
+def test_double_no_hitter_reports_the_home_side_as_the_deeper_bid() -> None:
+    feat = pitching_feat_progress(
+        _state(inning=7, phase=InningPhase.MIDDLE, away_hits=0, home_hits=0), min_completed_innings=6
+    )
+    assert feat is not None and feat.side is HomeAway.HOME
+
+
+def test_perfect_game_needs_a_confirmed_clean_sheet() -> None:
+    common: dict[str, object] = dict(inning=7, phase=InningPhase.TOP, away_hits=0, home_hits=3)
+    # The batting side is confirmed not to have reached -> perfect game.
+    perfect = pitching_feat_progress(_state(**common, away_reached_base=False), min_completed_innings=6)
+    assert perfect is not None and perfect.kind is PitchingFeatKind.PERFECT_GAME and perfect.perfect is True
+    # A confirmed baserunner -> plain no-hitter.
+    blemished = pitching_feat_progress(_state(**common, away_reached_base=True), min_completed_innings=6)
+    assert blemished is not None and blemished.kind is PitchingFeatKind.NO_HITTER and blemished.perfect is False
+    # Unknown (None) -> stay a plain no-hitter; never claim perfection without evidence.
+    unknown = pitching_feat_progress(_state(**common, away_reached_base=None), min_completed_innings=6)
+    assert unknown is not None and unknown.kind is PitchingFeatKind.NO_HITTER
+
+
+def test_perfect_game_reads_the_batting_side_for_an_away_pitcher() -> None:
+    # Home is hitless (away pitching); the relevant clean sheet is the *home* batting side's.
+    feat = pitching_feat_progress(
+        _state(inning=7, phase=InningPhase.END, away_hits=3, home_hits=0, home_reached_base=False),
+        min_completed_innings=6,
+    )
+    assert feat is not None and feat.side is HomeAway.AWAY and feat.perfect is True
+
+
+def test_pitching_feat_progress_rejects_zero_completed_innings() -> None:
+    with pytest.raises(ValueError):
+        PitchingFeatProgress(side=HomeAway.HOME, kind=PitchingFeatKind.NO_HITTER, completed_innings=0)
+
+
+def test_pitching_feat_kind_value_is_the_token() -> None:
+    assert PitchingFeatKind.PERFECT_GAME.value == "perfect_game"
+    assert PitchingFeatKind.NO_HITTER.value == "no_hitter"
 
 
 def test_pitch_type_value_is_the_statsapi_code() -> None:

--- a/tests/test_provider_game_state.py
+++ b/tests/test_provider_game_state.py
@@ -16,9 +16,11 @@ from omni.domain.contest import TeamGame
 from omni.providers.base import ProviderError
 from omni.providers.mlb_statsapi import (
     MlbStatsApiProvider,
+    _batting_walks_hbp,
     _parse_decisions,
     _parse_game_state,
     _phase_from_inning_state,
+    _reached_base,
 )
 from omni.providers.mlb_teams import MlbTeamRegistry
 
@@ -53,6 +55,49 @@ def test_parse_game_state_from_fixture() -> None:
     assert (state.count.balls, state.count.strikes, state.count.outs) == (2, 1, 2)
     # offense had first + third occupied; second empty.
     assert state.bases.first and state.bases.third and not state.bases.second
+    # both sides have hits, so both have plainly reached base.
+    assert state.away_reached_base is True and state.home_reached_base is True
+
+
+def _boxscore(side_stats: dict[str, dict[str, int]]) -> dict[str, Any]:
+    teams = {side: {"teamStats": {"batting": stats}} for side, stats in side_stats.items()}
+    return {"liveData": {"boxscore": {"teams": teams}}}
+
+
+def test_batting_walks_hbp_sums_from_the_boxscore() -> None:
+    assert _batting_walks_hbp(_boxscore({"away": {"baseOnBalls": 2, "hitByPitch": 1}}), "away") == 3
+
+
+def test_batting_walks_hbp_none_when_absent_or_null() -> None:
+    assert _batting_walks_hbp({"liveData": {}}, "away") is None  # no boxscore block
+    assert _batting_walks_hbp({"liveData": {"boxscore": None}}, "home") is None  # a null node degrades, never raises
+
+
+def test_reached_base_true_on_a_hit_or_a_defensive_error() -> None:
+    assert _reached_base({}, side="away", hits=1, fielding_errors=0) is True
+    assert _reached_base({}, side="away", hits=0, fielding_errors=1) is True  # reached on the defense's error
+
+
+def test_reached_base_unknown_without_the_boxscore() -> None:
+    # Hitless and errorless, but no walk/HBP data — unknown, so a perfect game is never claimed.
+    assert _reached_base({"liveData": {}}, side="away", hits=0, fielding_errors=0) is None
+
+
+def test_reached_base_clean_sheet_versus_a_walk() -> None:
+    clean = _boxscore({"home": {"baseOnBalls": 0, "hitByPitch": 0}})
+    assert _reached_base(clean, side="home", hits=0, fielding_errors=0) is False
+    walked = _boxscore({"home": {"baseOnBalls": 1, "hitByPitch": 0}})
+    assert _reached_base(walked, side="home", hits=0, fielding_errors=0) is True
+
+
+def test_parse_game_state_reads_a_clean_sheet_for_a_no_hit_side() -> None:
+    feed = _feed()
+    line = feed["liveData"]["linescore"]
+    line["teams"]["away"]["hits"] = 0  # away hitless...
+    line["teams"]["home"]["errors"] = 0  # ...and no away batter reached on a home error
+    feed["liveData"]["boxscore"] = {"teams": {"away": {"teamStats": {"batting": {"baseOnBalls": 0, "hitByPitch": 0}}}}}
+    state = _parse_game_state(feed)
+    assert state.away_hits == 0 and state.away_reached_base is False  # a clean sheet -> perfect-game eligible
 
 
 def test_fetch_live_feed_uses_injected_fetcher() -> None:


### PR DESCRIPTION
## What

Third item of **B1.5a** (correctness + lifecycle hardening): fix no-hitter / perfect-game progress.

The old `no_hitter_side(state, min_inning=…)` read the **current** inning, so a bid in the top of the 6th was shown as "through 6" (only 5 are finished) and surfaced a half-inning early. Perfect games were structurally supported by the card/renderer but **never populated** by the pipeline.

## Changes

- **Domain** (`omni/domain/baseball.py`): `PitchingFeatKind` {`NO_HITTER`, `PERFECT_GAME`} + frozen/slotted `PitchingFeatProgress(side, kind, completed_innings)`; pure `pitching_feat_progress(state, *, min_completed_innings)`. Completed innings are counted **per side** — the home side pitches the top, the away side the bottom, so a half-inning counts only once play moves past it. In a double no-hitter the home side is reported (it has always finished ≥ as many innings → the deeper/equal bid).
- **Perfect game**: `BaseballGameState` gains tri-state `away/home_reached_base` (`True`/`False`/`None`). A feat is promoted to `PERFECT_GAME` only on a **confirmed** clean sheet (`False`); unknown (`None`) stays a plain no-hitter, so perfection is never claimed without evidence.
- **Provider** (`mlb_statsapi.py`): `_parse_game_state` derives reached-base from boxscore walks/HBP + linescore errors (a hit or a defensive error is a definite baserunner). The `fields` whitelist is widened to pull the boxscore batting line + per-team errors. Counting an error as a baserunner only ever **under-reports** (calls a perfect game a no-hitter), never claims a false perfect game.
- **Pipeline** (`app/pipeline.py`): surfaces the corrected depth + `perfect` flag off the same delay-safe state, so the feat is revealed/un-revealed only as the broadcast would show.

## Verification

- **710 tests** green at **100% line+branch**; `mypy` + `black` clean.
- New tests pin: the side-specific completed-innings table across all four phases, the top-of-6th regression (now "through 5", not surfaced at min=6), perfect vs. plain vs. unknown clean-sheet, double no-hitter, the reached-base parse (hit / error / walk / unknown), and end-to-end perfect-game surfacing.
- **Dogfooded across 43 live finals** (2026-06-22…24): the widened whitelist returns errors+BB+HBP on real feeds, reached-base parses correctly (no false clean sheets), and the completed-innings arithmetic matches hand math.

No renderer change and no golden drift (the "THROUGH N" display now shows finished innings, which is what it always meant). Supported display profiles unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
