### PR TITLE
B1.5a: hold the last delay-safe frame across the final embargo (H1-adjacent)

### DIFF
--- a/omni/app/pipeline.py
+++ b/omni/app/pipeline.py
@@ -25,15 +25,18 @@ and a way to fetch a game's live feed; the pipeline cards each game for its phas
   ultimate spoiler, so the reveal is held until the broadcast lag elapses from when we
   first saw the game final (StatsAPI cannot report FINAL before the last out, so first
   sight + lag never predates the broadcast's ending); the card is then ingested and
-  lives out a finite post-game window. A walk-off that ended the game keeps draining from
-  the same delay-safe event stream, so it still flashes at its own release time — at or
-  just before the final — even though the game is already over.
+  lives out a finite post-game window. Through that embargo the game's **last delay-safe
+  live frame is held on screen** (its live card is not torn down until the final reveals),
+  so the board shows the last-aired state rather than going blank. A walk-off that ended
+  the game keeps draining from the same delay-safe event stream, so it still flashes at
+  its own release time — at or just before the final — even though the game is already over.
 
 A card is dropped when its game leaves that phase: the pregame card yields when the game
-goes live; the live and no-hitter cards are removed when the game is no longer live (a big
-play's own card lingers out its short window, then self-expires); the final card lingers
-its post-game window. So the queue mirrors the slate. Per-game fetch failures are isolated
-and reported, never fatal.
+goes live; the no-hitter card is removed when the game is no longer live; the live card is
+removed too, except a just-ended game holds its last delay-safe live frame through the final
+embargo, then swaps to the final (a big play's own card lingers out its short window, then
+self-expires); the final card lingers its post-game window. So the queue mirrors the slate.
+Per-game fetch failures are isolated and reported, never fatal.
 
 Baseball-only for now (it calls `pregame` / `score_live_baseball` / `live_baseball` /
 `big_play` / `no_hitter` / `final`), mirroring the per-sport renderer split; a generic
@@ -337,23 +340,28 @@ class LiveBaseballPipeline:
         """Drop per-game state for games that have moved on; return the carded ones.
 
         Live-scoped state (feed, live card, no-hitter card) is dropped the moment the game
-        leaves the live set — a big-play card is left to expire on its own short window, the
-        live and no-hitter cards are actively removed (a no-hitter ends with its game). The
-        event stream, though, keeps draining through the post-final window (so a held walk-off
-        still fires), so it is dropped only once the game leaves the slate entirely — or earlier,
-        at the final reveal, by which point it has drained. Only live-card removals are reported.
+        leaves the live set, with one exception: a *just-ended* game whose final reveal is still
+        embargoed keeps its last delay-safe live frame (card + feed) on screen — so the board
+        holds that frame instead of going blank through the post-game delay — until the final
+        card reveals (then the next pass, no longer pending, tears it down). The no-hitter card,
+        by contrast, is removed as soon as the game leaves the live set, embargo or not (an
+        in-progress bid is over once the game ends). A big-play card is left to expire on its own
+        short window; the event stream keeps draining through the post-final window (so a held
+        walk-off still fires), so it is dropped only once the game leaves the slate entirely — or
+        earlier, at the final reveal, by which point it has drained. Only live-card removals are reported.
         """
         live_scoped = set(self._feeds) | set(self._card_keys) | set(self._no_hitter_keys)
         removed_cards: list[LeagueScopedId] = []
         for contest_id in live_scoped - live_ids:
-            key = self._card_keys.pop(contest_id, None)
-            if key is not None:
-                self._queue.remove(key)
-                removed_cards.append(contest_id)
+            if contest_id not in self._final_pending:  # an embargoed final holds its last frame; do not tear down
+                key = self._card_keys.pop(contest_id, None)
+                if key is not None:
+                    self._queue.remove(key)
+                    removed_cards.append(contest_id)
+                self._feeds.pop(contest_id, None)
             no_hitter_key = self._no_hitter_keys.pop(contest_id, None)
             if no_hitter_key is not None:
                 self._queue.remove(no_hitter_key)
-            self._feeds.pop(contest_id, None)
         for contest_id in set(self._event_streams) - (live_ids | final_ids):
             self._event_streams.pop(contest_id, None)
         return tuple(sorted(removed_cards, key=str))

--- a/tests/test_app_pipeline.py
+++ b/tests/test_app_pipeline.py
@@ -584,6 +584,29 @@ def test_final_card_dropped_when_the_game_leaves_the_slate() -> None:
     assert _id("g1") not in pipe._final_keys and len(queue) == 0
 
 
+def test_last_live_frame_is_held_across_the_final_embargo() -> None:
+    # H1-adjacent: a just-ended game keeps its last delay-safe live frame on screen — never
+    # blank — through the post-game embargo, then the final card replaces it.
+    pipe, queue = _setup(lag=30)
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=2, home=5, inning=9))
+    pipe.refresh([_game("g1")], now=T, fetch_feed=fetch)  # live tick 1: observed, still inside the delay
+    live = pipe.refresh([_game("g1")], now=T + timedelta(seconds=30), fetch_feed=fetch)  # delay elapsed
+    assert [c.raw for c in live.ingested] == ["g1:live"]  # the last delay-safe frame is on screen
+
+    # The game ends; the final is embargoed (first sight + 30s), but the live frame is held.
+    held = pipe.refresh([_game("g1", GameStatus.FINAL)], now=T + timedelta(seconds=35), fetch_feed=fetch)
+    assert held.finals == () and _id("g1") in held.held
+    assert _id("g1") in pipe._card_keys and _id("g1") not in held.removed  # live card not torn down
+    card = queue.next_card(T + timedelta(seconds=35), QUAD)
+    assert card is not None and card.dedupe_key.raw == "g1:live"  # the last live frame, not blank
+
+    # Once the embargo elapses, the final reveals and the held frame is dropped in the same pass.
+    reveal = pipe.refresh([_game("g1", GameStatus.FINAL)], now=T + timedelta(seconds=65), fetch_feed=fetch)
+    assert [c.raw for c in reveal.finals] == ["g1:final"] and _id("g1") in reveal.removed
+    assert _id("g1") not in pipe._card_keys and len(queue) == 1  # the final replaced the held frame
+
+
 def test_pending_final_forgotten_if_the_game_resumes() -> None:
     # A game that flickers final -> live (a resumed suspension) drops its pending reveal, so a
     # stale captured score can never surface later.


### PR DESCRIPTION
## What

Fifth item of **B1.5a** (H1-adjacent): keep the board from going **blank during the post-game delay**.

When a game ends, `_drop_absent` tore down its live card the moment it left the live set — but the `final` card stays embargoed until *first-sight-of-FINAL + lag* (so the result never spoils the broadcast ending). Through that window the pipeline surfaced nothing for the game, and the display loop — asked to show nothing — keeps a stale frame (the H1 trap).

## Change

A game that is FINAL **but still in `_final_pending`** (embargoed) retains its live card (and feed) in `_drop_absent` instead of being torn down, so the board **holds the last delay-safe live frame** rather than going blank. Once the final reveals (no longer pending), the next pass tears the live frame down and the final card replaces it.

- The no-hitter card is still dropped the moment the game leaves the live set — an in-progress bid is over once the game ends (only the *score frame* is held).
- **Spoiler-safe by construction:** the held frame is the last state that already cleared the *live* TV delay (pre-final, already aired), so it reveals nothing the broadcast hasn't shown; the final result stays embargoed on its own first-sight anchor.

This is the pipeline-side piece of H1 — the dwell-enforcing display-state machine (idle/offline/hold) remains A1a; here the pipeline simply always offers a valid frame instead of relying on the display to hold a stale one.

## Verification

- **733 tests** green at **100% line+branch**; `mypy` + `black` clean. New multi-tick test drives live(delayed) → FINAL(embargo) → reveal and asserts the live frame is held (not blank, not the final) through the embargo, then dropped and replaced by the final.
- **Dogfooded** on a real game (TEX @ MIA, real parsed state 2-4, top 9th): `T+30` live shows the frame; `T+35` FINAL keeps showing it (`finals=[]`, `held=[823850]`); `T+70` reveals `final:823850:final` and drops the held frame. Before this change, `T+35` went blank.

Existing final-path tests are unaffected — they go straight to FINAL with no prior live card, so there is no frame to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
