### PR TITLE
chore: add 'Delayed: Tiebreaker' to legacy game-status data

### DIFF
--- a/data/status.py
+++ b/data/status.py
@@ -63,6 +63,7 @@ DELAYED_START_VENUE = "Delayed Start: Venue"  # Preview
 DELAYED_START_AIR_QUALITY = "Delayed Start: Air Quality"  # Preview
 DELAYED_START_WET_GROUNDS = "Delayed Start: Wet Grounds"  # Preview
 DELAYED_START_WIND = "Delayed Start: Wind"  # Preview
+DELAYED_TIEBREAKER = "Delayed: Tiebreaker"  # Live
 DELAYED_TRAGEDY = "Delayed: Tragedy"  # Live
 DELAYED_VENUE = "Delayed: Venue"  # Live
 DELAYED_WET_GROUNDS = "Delayed: Wet Grounds"  # Live
@@ -298,6 +299,7 @@ GAME_STATE_IRREGULAR = [
     DELAYED_START_VENUE,
     DELAYED_START_WET_GROUNDS,
     DELAYED_START_WIND,
+    DELAYED_TIEBREAKER,
     DELAYED_TRAGEDY,
     DELAYED_VENUE,
     DELAYED_WET_GROUNDS,


### PR DESCRIPTION
## What

MLB StatsAPI added a new `Delayed: Tiebreaker` game status. The upstream freshness test `test_data_up_to_date.py::test_status_complete` — a live `statsapi.meta("gameStatus")` check against `data/status.py` — started failing because the legacy status list didn't include it. (It passed in the #61/#62/#63 runs earlier today, so this is a fresh API addition, not a pre-existing miss.)

## Change

Add `DELAYED_TIEBREAKER = "Delayed: Tiebreaker"` and list it under `GAME_STATE_IRREGULAR` alongside the other delays. Two lines, restoring a green suite.

## Notes

- **Legacy/upstream data only.** The typed omni provider already handles this status correctly: `map_game_status` prefix-matches `"Delayed"` → `GameStatus.DELAYED` → a status card (the M2 path, #62). No omni change is needed — this just keeps the upstream freshness test honest.
- Surfaced while running QC for the M6 work (unrelated); split out so that stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
