### PR TITLE
B1.5a: AttentionPolicy mode invariants (reject nonsensical knob/mode combos)

### DIFF
--- a/omni/cards/attention.py
+++ b/omni/cards/attention.py
@@ -31,16 +31,38 @@ class AttentionMode(StrEnumMixin, str, Enum):
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class AttentionPolicy:
-    """A card's surfacing behavior — bounded so it can never monopolize forever."""
+    """A card's surfacing behavior — bounded so it can never monopolize forever.
+
+    Each knob belongs to exactly one mode (`takeover_for` to BURST, `cooldown`/`max_repeats`
+    to RECURRING); a knob set on any other mode would be silently ignored by the queue, so it
+    is rejected here rather than read as a working setting. A BURST must take over for a
+    positive duration (a zero-length burst never bursts) and a RECURRING needs a positive
+    cooldown (or it would resurface every tick, defeating the point) — both invariants the
+    queue then trusts instead of re-checking.
+    """
 
     mode: AttentionMode
-    takeover_for: DurationSeconds = DurationSeconds(0)  # how long a BURST holds the screen
-    cooldown: DurationSeconds = DurationSeconds(0)  # min gap before it may burst/recur again
-    max_repeats: int | None = None  # cap on RECURRING resurfacings (None = unbounded count)
+    takeover_for: DurationSeconds = DurationSeconds(0)  # how long a BURST holds the screen (BURST only)
+    cooldown: DurationSeconds = DurationSeconds(0)  # min gap before a RECURRING may resurface (RECURRING only)
+    max_repeats: int | None = None  # cap on RECURRING resurfacings (RECURRING only; None = unbounded count)
 
     def __post_init__(self) -> None:
-        if self.max_repeats is not None and self.max_repeats < 0:
-            raise ValueError("max_repeats cannot be negative")
+        if self.mode is AttentionMode.BURST:
+            if self.takeover_for.value <= 0:
+                raise ValueError("a BURST attention must take over for a positive duration")
+        elif self.takeover_for.value != 0:
+            raise ValueError("takeover_for is only meaningful for a BURST attention")
+
+        if self.mode is AttentionMode.RECURRING:
+            if self.cooldown.value <= 0:
+                raise ValueError("a RECURRING attention needs a positive cooldown")
+            if self.max_repeats is not None and self.max_repeats < 0:
+                raise ValueError("max_repeats cannot be negative")
+        else:
+            if self.cooldown.value != 0:
+                raise ValueError("cooldown is only meaningful for a RECURRING attention")
+            if self.max_repeats is not None:
+                raise ValueError("max_repeats is only meaningful for a RECURRING attention")
 
 
 # The default for a card that just wants fair rotation.

--- a/omni/queue/scheduler.py
+++ b/omni/queue/scheduler.py
@@ -131,8 +131,9 @@ class InterleavedCardQueue:
 
     def _is_bursting(self, card: ScoreboardCard[Any], now: datetime) -> bool:
         policy = card.attention
-        if policy.mode is not AttentionMode.BURST or policy.takeover_for.value <= 0:
+        if policy.mode is not AttentionMode.BURST:
             return False
+        # AttentionPolicy guarantees a BURST takes over for a positive duration, so this window is real.
         end = card.timing.available_at + policy.takeover_for.as_timedelta()
         return card.timing.available_at <= now < end
 

--- a/tests/test_cards_attention.py
+++ b/tests/test_cards_attention.py
@@ -32,21 +32,52 @@ def test_policy_defaults_are_inert() -> None:
 
 
 def test_bounded_burst_policy() -> None:
-    policy = AttentionPolicy(
-        mode=AttentionMode.BURST,
-        takeover_for=DurationSeconds(8),
-        cooldown=DurationSeconds(30),
-        max_repeats=1,
-    )
+    policy = AttentionPolicy(mode=AttentionMode.BURST, takeover_for=DurationSeconds(8))
     assert policy.mode is AttentionMode.BURST
     assert policy.takeover_for == DurationSeconds(8)
-    assert policy.max_repeats == 1
 
 
-def test_max_repeats_cannot_be_negative() -> None:
+def test_bounded_recurring_policy() -> None:
+    policy = AttentionPolicy(mode=AttentionMode.RECURRING, cooldown=DurationSeconds(60), max_repeats=3)
+    assert (policy.cooldown, policy.max_repeats) == (DurationSeconds(60), 3)
+    # A zero cap is allowed (capped at zero resurfacings); only negatives are rejected.
+    assert AttentionPolicy(mode=AttentionMode.RECURRING, cooldown=DurationSeconds(60), max_repeats=0).max_repeats == 0
+
+
+def test_burst_needs_a_positive_takeover() -> None:
+    with pytest.raises(ValueError, match="must take over for a positive duration"):
+        AttentionPolicy(mode=AttentionMode.BURST)  # takeover_for defaults to 0 — a no-op burst
+
+
+def test_recurring_needs_a_positive_cooldown() -> None:
+    with pytest.raises(ValueError, match="needs a positive cooldown"):
+        AttentionPolicy(mode=AttentionMode.RECURRING)  # cooldown defaults to 0 — would resurface every tick
+
+
+def test_recurring_max_repeats_cannot_be_negative() -> None:
     with pytest.raises(ValueError, match="max_repeats cannot be negative"):
-        AttentionPolicy(mode=AttentionMode.RECURRING, max_repeats=-1)
-    assert AttentionPolicy(mode=AttentionMode.RECURRING, max_repeats=0).max_repeats == 0  # zero is allowed
+        AttentionPolicy(mode=AttentionMode.RECURRING, cooldown=DurationSeconds(60), max_repeats=-1)
+
+
+@pytest.mark.parametrize("mode", [AttentionMode.NORMAL, AttentionMode.RECURRING, AttentionMode.BADGE])
+def test_takeover_for_rejected_off_burst(mode: AttentionMode) -> None:
+    with pytest.raises(ValueError, match="takeover_for is only meaningful for a BURST"):
+        AttentionPolicy(mode=mode, takeover_for=DurationSeconds(5))
+
+
+@pytest.mark.parametrize("mode", [AttentionMode.NORMAL, AttentionMode.BURST, AttentionMode.BADGE])
+def test_cooldown_rejected_off_recurring(mode: AttentionMode) -> None:
+    # A BURST carries a real takeover so it clears its own invariant; the cooldown is the violation.
+    takeover = DurationSeconds(8) if mode is AttentionMode.BURST else DurationSeconds(0)
+    with pytest.raises(ValueError, match="cooldown is only meaningful for a RECURRING"):
+        AttentionPolicy(mode=mode, takeover_for=takeover, cooldown=DurationSeconds(5))
+
+
+@pytest.mark.parametrize("mode", [AttentionMode.NORMAL, AttentionMode.BURST, AttentionMode.BADGE])
+def test_max_repeats_rejected_off_recurring(mode: AttentionMode) -> None:
+    takeover = DurationSeconds(8) if mode is AttentionMode.BURST else DurationSeconds(0)
+    with pytest.raises(ValueError, match="max_repeats is only meaningful for a RECURRING"):
+        AttentionPolicy(mode=mode, takeover_for=takeover, max_repeats=1)
 
 
 def test_normal_attention_constant() -> None:


### PR DESCRIPTION
## What

Sixth item of **B1.5a**: fix **M6** — `AttentionPolicy` permitted nonsensical combinations.

Every knob could be set on any mode, but each is read by exactly one: `takeover_for` by a BURST, `cooldown`/`max_repeats` by a RECURRING. A NORMAL/BADGE card with a `takeover_for`, a BURST with `max_repeats`, a zero-length BURST, or a cooldown-less RECURRING all constructed fine and were then **silently ignored** by the queue — settings that look like they do something but don't.

## Change

Bind each knob to the mode it governs and reject the rest in `__post_init__`:

- **`takeover_for`** is BURST-only; a BURST must take over for a **positive** duration (a zero-length burst never bursts — the queue's `_is_bursting` would skip it).
- **`cooldown`** and **`max_repeats`** are RECURRING-only; a RECURRING needs a **positive cooldown** or it resurfaces every tick, defeating "periodic, not constant".
- Every other mode must leave them at their inert defaults.

With the guarantee enforced at construction, the queue's `_is_bursting` drops its now-redundant `takeover_for > 0` re-check — the invariant lives in one place (the value object), and the queue trusts it.

## Verification

- **745 tests** green at **100% line+branch**; `mypy` + `black` clean.
- New tests cover each rejection (zero-length BURST, cooldown-less RECURRING, negative `max_repeats`, and each knob parametrized across the modes that may not carry it) plus the valid BURST/RECURRING/NORMAL shapes.
- All existing policies already satisfy the invariants — `NORMAL_ATTENTION` (defaults), the no-hitter `RECURRING` (`cooldown=60`), and the big-play `BURST` (`takeover_for=8/12`) — so nothing in the app changed behavior; this only closes the door on malformed ones.

Pure construction-time validation (no I/O / render), so the unit suite is the complete proof — nothing to dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
