### PR TITLE
B1.5a: GameEvent time/identity invariants (mirror Observation)

### DIFF
--- a/omni/events/base.py
+++ b/omni/events/base.py
@@ -72,6 +72,17 @@ class GameEvent(Generic[EventTypeT, PayloadT]):
     payload: PayloadT
     competitors: tuple[Competitor, ...] = ()
 
+    def __post_init__(self) -> None:
+        # Mirror Observation's time invariants — the TV-delay math mixes these two datetimes,
+        # so a naive one would raise mid-run — and require a real lineage id: an event's `id` is
+        # its dedupe/replay key (e.g. ``<gamePk>:ab:<atBatIndex>``), so an empty one would collide.
+        if not self.id.raw:
+            raise ValueError("a game event needs a non-empty id (its lineage key)")
+        if self.source_time.tzinfo is None:
+            raise ValueError("source_time must be timezone-aware")
+        if self.observed_at.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware")
+
     @property
     def league(self) -> League:
         return self.contest.league

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -96,6 +96,39 @@ def test_baseball_game_event_is_typed_and_derives_league() -> None:
     assert event.importance.combined_score() > 0
 
 
+def _event(
+    *,
+    event_id: LeagueScopedId | None = None,
+    source_time: datetime = T,
+    observed_at: datetime = T,
+) -> BaseballGameEvent:
+    return BaseballGameEvent(
+        id=event_id if event_id is not None else LeagueScopedId(League.MLB, SOURCE, "e1"),
+        contest=CONTEST,
+        event_type=BaseballGameEventType.HOME_RUN,
+        source=SOURCE,
+        source_time=source_time,
+        observed_at=observed_at,
+        importance=make_importance(),
+        payload=BaseballPlayPayload(inning=9, phase=InningPhase.TOP, description="homer"),
+    )
+
+
+def test_event_rejects_naive_timestamps() -> None:
+    # The delay math mixes source_time/observed_at, so a naive one must fail at construction.
+    naive = datetime(2026, 6, 17, 19, 5)
+    with pytest.raises(ValueError, match="source_time must be timezone-aware"):
+        _event(source_time=naive)
+    with pytest.raises(ValueError, match="observed_at must be timezone-aware"):
+        _event(observed_at=naive)
+
+
+def test_event_rejects_an_empty_lineage_id() -> None:
+    # The id is the dedupe/replay key; an empty one would collide with another event's.
+    with pytest.raises(ValueError, match="non-empty id"):
+        _event(event_id=LeagueScopedId(League.MLB, SOURCE, ""))
+
+
 def test_importance_accepts_inclusive_0_and_1_boundaries() -> None:
     imp = make_importance(leverage=0.0, rarity=1.0, favorite_relevance=0.0)
     assert imp.leverage == 0.0 and imp.rarity == 1.0


### PR DESCRIPTION
## What

Seventh item of **B1.5a**: fix **L1** — `GameEvent` lacks `Observation`'s time/identity invariants.

`Observation`, `DisplayTiming`, and the domain value objects all validate on construction, but `GameEvent` had no `__post_init__`: a naive `source_time`/`observed_at` (which the TV-delay math later mixes with aware datetimes and raises on, mid-run) or an empty lineage `id` could be built silently.

## Change

Add a `__post_init__` mirroring `Observation`'s invariants plus the event's identity key:

- both `source_time` and `observed_at` must be **timezone-aware**;
- `id` must be **non-empty** — it's the event's dedupe/replay key (`<gamePk>:ab:<atBatIndex>`), so an empty one would collide with another event's.

## Verification

- **747 tests** green at **100% line+branch**; `mypy` + `black` clean.
- New tests cover each rejection (naive `source_time`, naive `observed_at`, empty id).
- Every real construction — the provider's `_parse_one_play` (ISO-parsed aware times, `<contest>:ab:<idx>` id), fixtures, and tests — already satisfies these, so nothing changes behavior; it only fails fast on a malformed event.

Pure construction-time validation, so the unit suite is the complete proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
