### PR TITLE
B1.5b: wire the LogoStore into the running app's RenderContext

### DIFF
--- a/omni/app/__main__.py
+++ b/omni/app/__main__.py
@@ -22,6 +22,7 @@ from omni.core.time import DurationSeconds
 from omni.domain.contest import TeamGame
 from omni.events.baseball import LiveBaseballFeed
 from omni.panels.geometry import geometry_for
+from omni.renderers.image import LogoStore
 
 __all__ = ["main"]
 
@@ -82,6 +83,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - drives
         sink,
         favorites=frozenset(args.favorite),
         broadcast_lag=DurationSeconds(args.delay),
+        logos=LogoStore(),  # resolve committed team tiles from assets/ (lazy, cached)
     )
     print(f"omni.app: {profile.value}, delay {args.delay}s, favorites {sorted(args.favorite)} — http://localhost:8888/")
     run_forever(loop, SystemClock(), tick=DurationSeconds(args.tick))

--- a/omni/app/loop.py
+++ b/omni/app/loop.py
@@ -27,6 +27,7 @@ from omni.cards.base import CardId
 from omni.domain.contest import TeamGame
 from omni.queue.scheduler import InterleavedCardQueue
 from omni.renderers.context import RenderContext
+from omni.renderers.image import LogoStore
 from omni.renderers.registry import RendererRegistry
 
 __all__ = ["TickResult", "AppLoop"]
@@ -56,6 +57,7 @@ class AppLoop:
         registry: RendererRegistry,
         sink: DisplaySink,
         fetch_feed: FeedFetcher,
+        logos: LogoStore | None = None,
     ) -> None:
         self._supervisor = supervisor
         self._store = store
@@ -64,6 +66,7 @@ class AppLoop:
         self._registry = registry
         self._sink = sink
         self._fetch_feed = fetch_feed
+        self._logos = logos  # ambient tile store handed to every RenderContext; None -> colour-bar fallback
 
     def run_once(self, now: datetime) -> TickResult:
         """One full pass of the appliance as of ``now``."""
@@ -79,7 +82,7 @@ class AppLoop:
         if card is not None:
             try:
                 frame = self._sink.new_frame()
-                context = RenderContext(profile=self._sink.profile, now=now)
+                context = RenderContext(profile=self._sink.profile, now=now, logos=self._logos)
                 self._registry.render(card, context, frame)
                 self._sink.commit(frame)
                 shown = card.id

--- a/omni/app/runner.py
+++ b/omni/app/runner.py
@@ -24,6 +24,7 @@ from omni.providers.base import Provider
 from omni.queue.delay_policy import DelayPolicy
 from omni.queue.priority import PriorityScorer
 from omni.queue.scheduler import InterleavedCardQueue
+from omni.renderers.image import LogoStore
 from omni.renderers.registry import default_registry
 
 __all__ = ["build_loop", "run_forever"]
@@ -38,8 +39,13 @@ def build_loop(
     broadcast_lag: DurationSeconds = DurationSeconds(45),
     max_age: DurationSeconds = DurationSeconds(120),
     backoff: BackoffPolicy | None = None,
+    logos: LogoStore | None = None,
 ) -> AppLoop:
-    """Wire the standard spine into an `AppLoop` (deterministic; no I/O performed here)."""
+    """Wire the standard spine into an `AppLoop` (deterministic; no I/O performed here).
+
+    `logos`, when given, is the ambient tile store every render uses; left None (a
+    test/replay that doesn't care) the renderers fall back to a plain colour bar.
+    """
     queue = InterleavedCardQueue()
     pipeline = LiveBaseballPipeline(
         scorer=PriorityScorer(favorites=favorites),
@@ -55,6 +61,7 @@ def build_loop(
         registry=default_registry(),
         sink=sink,
         fetch_feed=fetch_feed,
+        logos=logos,
     )
 
 

--- a/omni/preview/cli.py
+++ b/omni/preview/cli.py
@@ -16,6 +16,7 @@ from omni.core.enum import PanelProfile
 from omni.panels.geometry import geometry_for
 from omni.preview.scenario import build_card_from_scenario
 from omni.renderers.context import RenderContext
+from omni.renderers.image import LogoStore
 from omni.renderers.matrix_canvas import MatrixCanvas
 from omni.renderers.registry import default_registry
 
@@ -60,7 +61,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - drives
     width, height = geometry_for(profile).size
     matrix = RGBMatrix(options=_configure_options(RGBMatrixOptions(), profile))
     frame = matrix.CreateFrameCanvas()
-    default_registry().render(card, RenderContext(profile=profile, now=now), MatrixCanvas(frame, width, height))
+    context = RenderContext(profile=profile, now=now, logos=LogoStore())
+    default_registry().render(card, context, MatrixCanvas(frame, width, height))
     matrix.SwapOnVSync(frame)
 
     import time

--- a/tests/test_app_loop.py
+++ b/tests/test_app_loop.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from omni.app.contest_store import ContestStore
 from omni.app.display import RecordingDisplaySink
 from omni.app.loop import AppLoop
 from omni.app.pipeline import LiveBaseballPipeline
 from omni.app.supervisor import ProviderStatus, ProviderSupervisor
+from omni.cards.base import ScoreboardCard
 from omni.cards.factory import CardFactory
 from omni.core.enum import GameStatus, League, PanelProfile
 from omni.core.ids import LeagueScopedId, SourceRef
@@ -21,6 +23,9 @@ from omni.providers.mlb_teams import MlbTeamRegistry
 from omni.queue.delay_policy import DelayPolicy
 from omni.queue.priority import PriorityScorer
 from omni.queue.scheduler import InterleavedCardQueue
+from omni.renderers.canvas import Canvas
+from omni.renderers.context import RenderContext
+from omni.renderers.image import LogoStore
 from omni.renderers.registry import RendererRegistry, default_registry
 
 _REG = MlbTeamRegistry.from_color_file()
@@ -71,8 +76,25 @@ def _fetch_feed(game: TeamGame, now: datetime) -> LiveBaseballFeed:
     return LiveBaseballFeed(state=_state())
 
 
+class _CapturingRegistry(RendererRegistry):
+    """Wraps a real registry, recording the RenderContext the loop hands each render."""
+
+    def __init__(self, inner: RendererRegistry) -> None:
+        super().__init__()
+        self._inner = inner
+        self.last_context: RenderContext | None = None
+
+    def render(self, card: ScoreboardCard[Any], context: RenderContext, canvas: Canvas) -> None:
+        self.last_context = context
+        self._inner.render(card, context, canvas)
+
+
 def _build(
-    *, lag: int = 0, registry: RendererRegistry | None = None, provider: _Provider | None = None
+    *,
+    lag: int = 0,
+    registry: RendererRegistry | None = None,
+    provider: _Provider | None = None,
+    logos: LogoStore | None = None,
 ) -> tuple[AppLoop, RecordingDisplaySink, _Provider]:
     queue = InterleavedCardQueue()
     pipeline = LiveBaseballPipeline(
@@ -91,6 +113,7 @@ def _build(
         registry=registry if registry is not None else default_registry(),
         sink=sink,
         fetch_feed=_fetch_feed,
+        logos=logos,
     )
     return loop, sink, provider
 
@@ -141,3 +164,22 @@ def test_run_once_isolates_a_render_failure() -> None:
     assert res.shown is None
     assert sink.committed == 0  # nothing committed on failure
     assert res.pipeline.ingested  # but the pipeline still built + ingested the card
+
+
+def test_run_once_threads_the_logo_store_into_the_render_context() -> None:
+    # The running app's logo store must reach the renderer as ambient RenderContext.
+    capturing = _CapturingRegistry(default_registry())
+    store = LogoStore()
+    loop, _, _ = _build(lag=0, registry=capturing, logos=store)
+    loop.run_once(T)
+    assert capturing.last_context is not None
+    assert capturing.last_context.logos is store
+
+
+def test_run_once_defaults_to_no_logo_store() -> None:
+    # A loop built without logos (a test/replay) renders with the colour-bar fallback.
+    capturing = _CapturingRegistry(default_registry())
+    loop, _, _ = _build(lag=0, registry=capturing)
+    loop.run_once(T)
+    assert capturing.last_context is not None
+    assert capturing.last_context.logos is None

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -15,6 +15,8 @@ from omni.domain.contest import TeamGame
 from omni.events.baseball import LiveBaseballFeed
 from omni.providers.base import ProviderUpdate
 from omni.providers.mlb_teams import MlbTeamRegistry
+from omni.renderers.canvas import RecordingCanvas
+from omni.renderers.image import LogoStore
 
 _REG = MlbTeamRegistry.from_color_file()
 SOURCE = SourceRef("mlb_statsapi", "https://statsapi.mlb.com")
@@ -49,6 +51,8 @@ def _fetch_feed(game: TeamGame, now: datetime) -> LiveBaseballFeed:
             phase=InningPhase.BOTTOM,
             count=BaseballCount(balls=2, strikes=1, outs=1),
             bases=BaseballBaseState(first=True),
+            away_hits=5,  # a normal mid-game state — hits present, so no no-hitter card pre-empts the live card
+            home_hits=7,
         )
     )
 
@@ -67,6 +71,26 @@ def test_build_loop_wires_the_broadcast_delay() -> None:
     assert loop.run_once(T).shown is None  # inside the delay — nothing shown yet
     assert loop.run_once(T + timedelta(seconds=30)).shown is not None
     assert sink.committed == 1
+
+
+def test_build_loop_threads_logos_through_to_the_rendered_frame() -> None:
+    # A LogoStore handed to build_loop must reach rendering: the quad live card blits team tiles.
+    sink = RecordingDisplaySink(PanelProfile.QUAD_128X64)
+    loop = build_loop(_Provider(), _fetch_feed, sink, broadcast_lag=DurationSeconds(0), logos=LogoStore())
+    loop.run_once(T)
+    frame = sink.frames[-1]
+    assert isinstance(frame, RecordingCanvas)
+    assert frame.images()  # tiles blitted — the store reached the renderer end to end
+
+
+def test_build_loop_without_logos_falls_back_to_colour_bars() -> None:
+    # No store wired (a test/replay) → the renderer draws colour bars, never a tile blit.
+    sink = RecordingDisplaySink(PanelProfile.QUAD_128X64)
+    loop = build_loop(_Provider(), _fetch_feed, sink, broadcast_lag=DurationSeconds(0))
+    loop.run_once(T)
+    frame = sink.frames[-1]
+    assert isinstance(frame, RecordingCanvas)
+    assert not frame.images()  # colour-bar fallback, no blits
 
 
 def test_parse_args_defaults() -> None:


### PR DESCRIPTION
## What

First PR of **B1.5b** (live-dashboard density + visual integration). Closes the **logo half of H4**: the team-logo system was renderer-only — `AppLoop` built its `RenderContext` with no logo store, so the committed tiles never reached the running app and every card fell back to a plain colour bar.

Threads an optional `LogoStore` through `build_loop` → `AppLoop` → `RenderContext` (and the preview CLI), defaulting to `None` so tests and replay keep the colour-bar fallback unchanged. The emulator entry (`python -m omni.app`) now wires a real `LogoStore()` (lazy, cached from `assets/`).

This is **pure ambient-context wiring** — renderers already consume `context.logos`; no data-path change. The win-prob meter half of H4 (delay-safe `win_probability` population) is the next PR.

## Why it's correct

- `RenderContext.logos` was already an optional field with a documented colour-bar fallback; the only running-app seam that built it (`loop.py`) omitted it.
- Backward-compatible: every existing call site (tests, replay harness) passes no `logos` and behaves exactly as before.

## Verification

- **Capturing-registry test** — the loop threads its store into the `RenderContext` it builds (and defaults to `None`).
- **Behavioral end-to-end test** — a real `LogoStore` passed to `build_loop` blits committed tiles onto the rendered frame (`frame.images()` non-empty); without a store, no blits.
- **Live-slate dogfood** — built the loop exactly as `__main__` does and ran one tick against the real provider: a live game (**ATH @ SF**) rendered with both team tiles (`ath`, `sf`) on the committed frame.
- **Full gate green:** 751 tests (4 new), `omni/` 100% line+branch, `mypy` + `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)