### PR TITLE
B1.5b: populate the win-probability meter, delay-safe

### DIFF
--- a/omni/app/__main__.py
+++ b/omni/app/__main__.py
@@ -19,6 +19,7 @@ from omni.app.display import MatrixDevice, MatrixDisplaySink
 from omni.app.runner import build_loop, run_forever
 from omni.core.enum import PanelProfile
 from omni.core.time import DurationSeconds
+from omni.domain.baseball import WinProbability
 from omni.domain.contest import TeamGame
 from omni.events.baseball import LiveBaseballFeed
 from omni.panels.geometry import geometry_for
@@ -64,6 +65,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - drives
     def fetch_feed(game: TeamGame, now: datetime) -> LiveBaseballFeed:
         return provider.fetch_live_feed(game, now=now)
 
+    def fetch_win_probability(game: TeamGame) -> WinProbability | None:
+        return provider.fetch_win_probability(game)
+
     from RGBMatrixEmulator import RGBMatrix, RGBMatrixOptions
 
     options = RGBMatrixOptions()
@@ -83,6 +87,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - drives
         sink,
         favorites=frozenset(args.favorite),
         broadcast_lag=DurationSeconds(args.delay),
+        fetch_win_probability=fetch_win_probability,  # per-team meter, delayed in lockstep with the score
         logos=LogoStore(),  # resolve committed team tiles from assets/ (lazy, cached)
     )
     print(f"omni.app: {profile.value}, delay {args.delay}s, favorites {sorted(args.favorite)} — http://localhost:8888/")

--- a/omni/app/loop.py
+++ b/omni/app/loop.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 from omni.app.contest_store import ContestStore, Reconciliation
 from omni.app.display import DisplaySink
-from omni.app.pipeline import FeedFetcher, LiveBaseballPipeline, PipelineResult
+from omni.app.pipeline import FeedFetcher, LiveBaseballPipeline, PipelineResult, WinProbFetcher
 from omni.app.supervisor import ProviderStatus, ProviderSupervisor
 from omni.cards.base import CardId
 from omni.domain.contest import TeamGame
@@ -57,6 +57,7 @@ class AppLoop:
         registry: RendererRegistry,
         sink: DisplaySink,
         fetch_feed: FeedFetcher,
+        fetch_win_probability: WinProbFetcher | None = None,
         logos: LogoStore | None = None,
     ) -> None:
         self._supervisor = supervisor
@@ -66,6 +67,7 @@ class AppLoop:
         self._registry = registry
         self._sink = sink
         self._fetch_feed = fetch_feed
+        self._fetch_win_probability = fetch_win_probability  # optional per-game win-prob fetch; None -> no meter
         self._logos = logos  # ambient tile store handed to every RenderContext; None -> colour-bar fallback
 
     def run_once(self, now: datetime) -> TickResult:
@@ -74,7 +76,12 @@ class AppLoop:
         reconciliation = self._store.apply(snapshot.update) if snapshot.update is not None else None
 
         team_games = [contest for contest in self._store.contests if isinstance(contest, TeamGame)]
-        pipeline_result = self._pipeline.refresh(team_games, now=now, fetch_feed=self._fetch_feed)
+        pipeline_result = self._pipeline.refresh(
+            team_games,
+            now=now,
+            fetch_feed=self._fetch_feed,
+            fetch_win_probability=self._fetch_win_probability,
+        )
 
         card = self._queue.next_card(now, self._sink.profile)
         shown: CardId | None = None

--- a/omni/app/pipeline.py
+++ b/omni/app/pipeline.py
@@ -21,6 +21,11 @@ and a way to fetch a game's live feed; the pipeline cards each game for its phas
     hitless past a minimum inning a `RECURRING` no-hitter card is surfaced and refreshed,
     and removed the moment a hit (in the *delayed* state) breaks the bid — so the bid is
     revealed and un-revealed only as the broadcast would show it.
+  - **win probability** — the live card's per-team meter. A separate, cheaper fetch whose
+    *current* reading is pushed into a per-game delay feed on the same ticks as the state, so
+    the surfaced reading is from the same lag-old moment as the shown score — stale-safe, never
+    leading it. A fetch failure is non-fatal (the card shows without a meter); absent until the
+    game has run long enough for a reading to clear the lag.
 - **final** — once a game ends, a `final` card with the box score. The result is the
   ultimate spoiler, so the reveal is held until the broadcast lag elapses from when we
   first saw the game final (StatsAPI cannot report FINAL before the last out, so first
@@ -55,7 +60,7 @@ from omni.cards.factory import CardFactory
 from omni.core.enum import DisplayPriority, GameStatus
 from omni.core.ids import LeagueScopedId
 from omni.core.observation import Observation
-from omni.domain.baseball import BaseballGameState, PitchingDecisions, pitching_feat_progress
+from omni.domain.baseball import BaseballGameState, PitchingDecisions, WinProbability, pitching_feat_progress
 from omni.domain.contest import TeamGame
 from omni.events.baseball import BaseballGameEvent, LiveBaseballFeed
 from omni.providers.base import ProviderError
@@ -65,11 +70,16 @@ from omni.queue.delayed_feed import DelayedFeed
 from omni.queue.priority import PriorityScorer
 from omni.queue.scheduler import InterleavedCardQueue
 
-__all__ = ["FeedFetcher", "PipelineResult", "LiveBaseballPipeline"]
+__all__ = ["FeedFetcher", "WinProbFetcher", "PipelineResult", "LiveBaseballPipeline"]
 
 # How the pipeline pulls one game's live feed as of `now` (wraps the provider's
 # per-game fetch): the current state plus the play-by-play events from the same fetch.
 FeedFetcher = Callable[[TeamGame, datetime], LiveBaseballFeed]
+
+# How the pipeline pulls one game's current win probability (a separate, cheaper call than
+# the feed). Returns None when none is available yet (pregame / a payload without it). The
+# *current* reading — the pipeline delays it itself so the meter never leads the shown score.
+WinProbFetcher = Callable[[TeamGame], WinProbability | None]
 
 # Pre-first-pitch states: both carry a pregame card (a scheduled game later today and one
 # in warmups are both "upcoming"). Mid-game oddities (DELAYED/SUSPENDED) are not pregame.
@@ -118,6 +128,9 @@ class LiveBaseballPipeline:
         self._pregame_keys: dict[LeagueScopedId, str] = {}  # contest id -> its pregame card's key
         self._status_keys: dict[LeagueScopedId, str] = {}  # contest id -> its (delay/suspension) status card's key
         self._feeds: dict[LeagueScopedId, DelayedFeed[BaseballGameState]] = {}
+        # contest id -> its win-probability timeline; delayed in lockstep with the state feed so the
+        # meter shows the reading from the same lag-old moment as the score (never a fresher one).
+        self._win_prob_feeds: dict[LeagueScopedId, DelayedFeed[WinProbability]] = {}
         self._card_keys: dict[LeagueScopedId, str] = {}  # contest id -> its live card's dedupe key
         self._event_streams: dict[LeagueScopedId, DelayedEventStream[BaseballGameEvent]] = {}
         self._no_hitter_keys: dict[LeagueScopedId, str] = {}  # contest id -> its no-hitter card's key
@@ -125,8 +138,20 @@ class LiveBaseballPipeline:
         self._final_pending: dict[LeagueScopedId, datetime] = {}
         self._final_keys: dict[LeagueScopedId, str] = {}  # contest id -> its (revealed) final card's key
 
-    def refresh(self, games: Iterable[TeamGame], *, now: datetime, fetch_feed: FeedFetcher) -> PipelineResult:
-        """Observe the slate, surface each game's phase card into the queue, drop stale ones."""
+    def refresh(
+        self,
+        games: Iterable[TeamGame],
+        *,
+        now: datetime,
+        fetch_feed: FeedFetcher,
+        fetch_win_probability: WinProbFetcher | None = None,
+    ) -> PipelineResult:
+        """Observe the slate, surface each game's phase card into the queue, drop stale ones.
+
+        `fetch_win_probability`, when given, supplies each live game's current win probability;
+        the pipeline buffers it through the same TV delay as the state so the meter never leads
+        the shown score. Omitted (a test, or the meter disabled) the live card carries no meter.
+        """
         live = [game for game in games if game.status is GameStatus.LIVE]
         upcoming = [game for game in games if game.status in _UPCOMING_STATUSES]
         irregular = [game for game in games if game.status in STATUS_CARD_STATUSES]
@@ -173,8 +198,13 @@ class LiveBaseballPipeline:
             if safe is None:
                 held.append(game.id)  # still inside the TV delay — nothing safe to show yet
                 continue
+            # Win probability rides its own delay buffer, pushed on the same ticks as the state, so
+            # the surfaced reading is from the same lag-old moment as the score — never a fresher one.
+            win_prob, wp_warning = self._safe_win_probability(game, fetch_win_probability, now=now)
+            if wp_warning is not None:
+                warnings.append(f"{game.id.raw}: {wp_warning}")
             priority = self._scorer.score_live_baseball(game, safe.value)
-            card = self._factory.live_baseball(game, safe.value, now=now, priority=priority)
+            card = self._factory.live_baseball(game, safe.value, now=now, priority=priority, win_probability=win_prob)
             self._queue.ingest(card)
             self._card_keys[game.id] = card.dedupe_key.raw
             ingested.append(card.id)
@@ -233,6 +263,31 @@ class LiveBaseballPipeline:
         self._queue.ingest(card)
         self._status_keys[game.id] = card.dedupe_key.raw
         return card.id
+
+    def _safe_win_probability(
+        self, game: TeamGame, fetcher: WinProbFetcher | None, *, now: datetime
+    ) -> tuple[WinProbability | None, str | None]:
+        """The TV-safe win probability for this game's live card, plus any fetch-failure warning.
+
+        Fetches the *current* reading and pushes it into a per-game delay feed at ``now``, then
+        returns the newest reading that has cleared the broadcast lag — i.e. the one from the same
+        ``now - lag`` moment as the lag-old state the card shows. So the meter can be a touch stale
+        but never leads the score. With no fetcher (the meter disabled) it is a no-op returning None;
+        a fetch failure is non-fatal (the live card still shows) and surfaced as a warning.
+        """
+        if fetcher is None:
+            return None, None
+        warning: str | None = None
+        try:
+            current = fetcher(game)
+        except ProviderError as exc:
+            current = None
+            warning = f"win-probability fetch failed: {exc}"
+        feed = self._win_prob_feeds.setdefault(game.id, DelayedFeed(self._delay))
+        if current is not None:
+            feed.push(Observation(subject_id=game.id, source=game.id.source, observed_at=now, value=current))
+        eligible = feed.latest_eligible(now)
+        return (eligible.value if eligible is not None else None), warning
 
     def _surface_big_plays(
         self, game: TeamGame, events: tuple[BaseballGameEvent, ...], *, now: datetime
@@ -359,6 +414,7 @@ class LiveBaseballPipeline:
                     self._queue.remove(key)
                     removed_cards.append(contest_id)
                 self._feeds.pop(contest_id, None)
+                self._win_prob_feeds.pop(contest_id, None)  # win-prob buffer rides the state feed's lifecycle
             no_hitter_key = self._no_hitter_keys.pop(contest_id, None)
             if no_hitter_key is not None:
                 self._queue.remove(no_hitter_key)

--- a/omni/app/runner.py
+++ b/omni/app/runner.py
@@ -16,7 +16,7 @@ from omni.app.clock import Clock
 from omni.app.contest_store import ContestStore
 from omni.app.display import DisplaySink
 from omni.app.loop import AppLoop
-from omni.app.pipeline import FeedFetcher, LiveBaseballPipeline
+from omni.app.pipeline import FeedFetcher, LiveBaseballPipeline, WinProbFetcher
 from omni.app.supervisor import BackoffPolicy, ProviderSupervisor
 from omni.cards.factory import CardFactory
 from omni.core.time import DurationSeconds
@@ -39,10 +39,13 @@ def build_loop(
     broadcast_lag: DurationSeconds = DurationSeconds(45),
     max_age: DurationSeconds = DurationSeconds(120),
     backoff: BackoffPolicy | None = None,
+    fetch_win_probability: WinProbFetcher | None = None,
     logos: LogoStore | None = None,
 ) -> AppLoop:
     """Wire the standard spine into an `AppLoop` (deterministic; no I/O performed here).
 
+    `fetch_win_probability`, when given, feeds each live game's win-prob meter (delayed in
+    the pipeline so it never leads the shown score); omitted, the live card carries no meter.
     `logos`, when given, is the ambient tile store every render uses; left None (a
     test/replay that doesn't care) the renderers fall back to a plain colour bar.
     """
@@ -61,6 +64,7 @@ def build_loop(
         registry=default_registry(),
         sink=sink,
         fetch_feed=fetch_feed,
+        fetch_win_probability=fetch_win_probability,
         logos=logos,
     )
 

--- a/omni/cards/factory.py
+++ b/omni/cards/factory.py
@@ -36,7 +36,7 @@ from omni.cards.baseball import (
 )
 from omni.core.enum import DisplayPriority, GameStatus, HomeAway, PanelProfile
 from omni.core.time import DurationSeconds
-from omni.domain.baseball import BaseballGameState, PitchingDecisions
+from omni.domain.baseball import BaseballGameState, PitchingDecisions, WinProbability
 from omni.domain.contest import TeamGame
 from omni.events.baseball import BaseballGameEvent
 
@@ -126,8 +126,14 @@ class CardFactory:
         *,
         now: datetime,
         priority: CardPriority | None = None,
+        win_probability: WinProbability | None = None,
     ) -> ScoreboardCard[LiveBaseballCardPayload]:
-        """Build a live MLB card from a matchup + its observed game state."""
+        """Build a live MLB card from a matchup + its observed game state.
+
+        `win_probability`, when given, drives the per-team meter; the caller is
+        responsible for handing in a *delay-safe* sample (one matching the lag-old
+        state), never a fresh reading — see the pipeline's win-probability path.
+        """
         payload = LiveBaseballCardPayload(
             away_score=state.away_score,
             home_score=state.home_score,
@@ -135,6 +141,7 @@ class CardFactory:
             phase=state.phase,
             count=state.count,
             bases=state.bases,
+            win_probability=win_probability,
         )
         key = f"{game.id.raw}:live"
         return ScoreboardCard(

--- a/tests/test_app_pipeline.py
+++ b/tests/test_app_pipeline.py
@@ -9,7 +9,14 @@ from omni.cards.factory import CardFactory
 from omni.core.enum import DisplayPriority, GameStatus, League, PanelProfile, UpdateUrgency
 from omni.core.ids import LeagueScopedId, SourceRef
 from omni.core.time import DurationSeconds
-from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, InningPhase, PitchingDecisions
+from omni.domain.baseball import (
+    BaseballBaseState,
+    BaseballCount,
+    BaseballGameState,
+    InningPhase,
+    PitchingDecisions,
+    WinProbability,
+)
 from omni.domain.contest import TeamGame
 from omni.events.base import EventImportance
 from omni.events.baseball import BaseballGameEvent, BaseballGameEventType, BaseballPlayPayload, LiveBaseballFeed
@@ -117,6 +124,21 @@ class _Fetch:
         )
 
 
+class _WinProb:
+    """A configurable win-probability fetcher; can be set per refresh and made to fail."""
+
+    def __init__(self) -> None:
+        self.value: WinProbability | None = None
+        self.calls: list[str] = []
+        self.fail: set[str] = set()
+
+    def __call__(self, game: TeamGame) -> WinProbability | None:
+        self.calls.append(game.id.raw)
+        if game.id.raw in self.fail:
+            raise ProviderError("win-probability feed down")
+        return self.value
+
+
 def _setup(lag: int = 30) -> tuple[LiveBaseballPipeline, InterleavedCardQueue]:
     queue = InterleavedCardQueue()
     pipe = LiveBaseballPipeline(
@@ -156,6 +178,80 @@ def test_shows_lag_old_state_not_the_current_spoiler() -> None:
     card = queue.next_card(T + timedelta(seconds=30), QUAD)
     assert card is not None
     assert card.payload.home_score == 0  # the delayed 0-0, never the un-aired 0-1
+
+
+def test_win_probability_is_delay_safe_never_leads_the_score() -> None:
+    # The meter must show the reading from the same lag-old moment as the score, never a fresher one.
+    pipe, queue = _setup(lag=30)
+    fetch = _Fetch()
+    fetch.set("g1", _state())
+    wp = _WinProb()
+    early = WinProbability(home=60.0, away=40.0)
+    later = WinProbability(home=95.0, away=5.0)
+
+    pipe.refresh([_game("g1")], now=T, fetch_feed=fetch, fetch_win_probability=wp)  # state held; no win-prob yet
+    assert wp.calls == []  # nothing fetched while the state is still buffering
+
+    wp.value = early
+    at30 = T + timedelta(seconds=30)
+    pipe.refresh([_game("g1")], now=at30, fetch_feed=fetch, fetch_win_probability=wp)  # state surfaces; early pushed
+    c1 = queue.next_card(at30, QUAD)
+    assert c1 is not None and c1.payload.win_probability is None  # warm-up: early has not cleared the lag yet
+
+    wp.value = later  # a fresher reading arrives...
+    at60 = T + timedelta(seconds=60)
+    pipe.refresh([_game("g1")], now=at60, fetch_feed=fetch, fetch_win_probability=wp)
+    c2 = queue.next_card(at60, QUAD)
+    assert c2 is not None and c2.payload.win_probability == early  # ...but the meter shows the delayed `early`
+
+
+def test_win_probability_surfaces_once_clear_of_a_zero_lag() -> None:
+    # With no delay the happy path attaches the current reading immediately.
+    pipe, queue = _setup(lag=0)
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=1, home=2))
+    wp = _WinProb()
+    wp.value = WinProbability(home=70.0, away=30.0)
+    pipe.refresh([_game("g1")], now=T, fetch_feed=fetch, fetch_win_probability=wp)
+    card = queue.next_card(T, QUAD)
+    assert card is not None and card.payload.win_probability == WinProbability(home=70.0, away=30.0)
+
+
+def test_no_win_probability_fetcher_means_no_meter() -> None:
+    # Omitting the fetcher (the meter disabled) leaves the live card's win_probability None.
+    pipe, queue = _setup(lag=0)
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=1, home=2))
+    pipe.refresh([_game("g1")], now=T, fetch_feed=fetch)
+    card = queue.next_card(T, QUAD)
+    assert card is not None and card.payload.win_probability is None
+
+
+def test_win_probability_fetch_failure_is_a_nonfatal_warning() -> None:
+    # A win-prob fetch failure must not drop the live card — it shows without a meter, plus a warning.
+    pipe, queue = _setup(lag=0)
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=1, home=2))
+    wp = _WinProb()
+    wp.fail.add("g1")
+    res = pipe.refresh([_game("g1")], now=T, fetch_feed=fetch, fetch_win_probability=wp)
+    assert len(res.ingested) == 1 and res.skipped == ()  # the live card still shows; not a game drop
+    assert any("win-probability" in warning for warning in res.warnings)
+    card = queue.next_card(T, QUAD)
+    assert card is not None and card.payload.win_probability is None  # no meter on a failed fetch
+
+
+def test_win_probability_buffer_is_released_when_the_game_leaves() -> None:
+    # The per-game win-prob buffer rides the state feed's lifecycle — dropped with the game, no leak.
+    pipe, _queue = _setup(lag=0)
+    fetch = _Fetch()
+    fetch.set("g1", _state(away=1, home=2))
+    wp = _WinProb()
+    wp.value = WinProbability(home=70.0, away=30.0)
+    pipe.refresh([_game("g1")], now=T, fetch_feed=fetch, fetch_win_probability=wp)
+    assert _id("g1") in pipe._win_prob_feeds  # a buffer exists while the game is live
+    pipe.refresh([], now=T + timedelta(seconds=1), fetch_feed=fetch, fetch_win_probability=wp)
+    assert _id("g1") not in pipe._win_prob_feeds  # gone with the game
 
 
 def test_a_non_carding_status_surfaces_nothing() -> None:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -10,7 +10,7 @@ from omni.app.runner import build_loop
 from omni.core.enum import GameStatus, League, PanelProfile
 from omni.core.ids import LeagueScopedId, SourceRef
 from omni.core.time import DurationSeconds
-from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, InningPhase
+from omni.domain.baseball import BaseballBaseState, BaseballCount, BaseballGameState, InningPhase, WinProbability
 from omni.domain.contest import TeamGame
 from omni.events.baseball import LiveBaseballFeed
 from omni.providers.base import ProviderUpdate
@@ -91,6 +91,20 @@ def test_build_loop_without_logos_falls_back_to_colour_bars() -> None:
     frame = sink.frames[-1]
     assert isinstance(frame, RecordingCanvas)
     assert not frame.images()  # colour-bar fallback, no blits
+
+
+def test_build_loop_threads_the_win_probability_fetcher() -> None:
+    # A win-prob fetcher handed to build_loop must reach the pipeline's live path.
+    sink = RecordingDisplaySink(PanelProfile.QUAD_128X64)
+    calls: list[str] = []
+
+    def fetch_wp(game: TeamGame) -> WinProbability | None:
+        calls.append(game.id.raw)
+        return WinProbability(home=70.0, away=30.0)
+
+    loop = build_loop(_Provider(), _fetch_feed, sink, broadcast_lag=DurationSeconds(0), fetch_win_probability=fetch_wp)
+    loop.run_once(T)
+    assert calls == ["g1"]  # the pipeline fetched win-prob for the live game
 
 
 def test_parse_args_defaults() -> None:


### PR DESCRIPTION
## What

Second PR of **B1.5b**. Closes the **meter half of H4**: the live card's per-team win-probability meter was renderer-only — `LiveBaseballCardPayload.win_probability` was never populated, so the meter never appeared in the running app.

Wires a caller-cadenced win-probability fetch through `build_loop` → `AppLoop` → pipeline and populates the field — **delayed so it can never spoil**.

## Delay-safety (the head's hard constraint: never attach fresh win-prob to a delayed score)

Met **structurally**, not by a check:

- The pipeline pushes each *current* reading into a per-game `DelayedFeed[WinProbability]` **on the same ticks as the state feed**, then attaches the newest reading that has cleared the broadcast lag.
- State and win-prob are anchored identically (receipt-time + lag), so the surfaced reading is from the **same `now − lag` moment as the shown score** — stale-safe, never leading it.
- During warm-up (before any reading clears the lag) the meter is simply absent (`None`).
- The fetch runs *after* the state's delay-hold check, so a game still inside its initial delay fetches no win-prob.

## Robustness

- A win-prob fetch failure is **non-fatal**: the live card still shows, with a `warnings` entry and no meter (never a dropped game).
- The per-game buffer rides the state feed's lifecycle — dropped with the game, kept through a final embargo.
- The fetcher is **optional throughout**, so tests and replay (no fetcher) are unchanged and carry no meter; existing live goldens are untouched.

## Scope notes

- Cadence stays **every-tick** for now, consistent with the existing state fetch; a `PollPlan` will throttle both together in **A1a** (H6).
- The visual win-prob **trend** (direction over recent samples) is deferred to the density dashboard (M1).

## Verification

- **Deterministic pipeline tests** — the meter shows the lag-old reading and **never** the fresh one across a delay window; warm-up shows none; a fetch failure is a non-fatal warning; the buffer is released with the game.
- **Threading test** — a fetcher handed to `build_loop` reaches the pipeline's live path.
- **Live-slate dogfood** — the real provider returned `WinProbability(home=94.3, away=5.7)` for a live game (**ATH @ SF**) and the pipeline attached it to the surfaced live card.
- **Gate green:** 757 tests (6 new), `omni/` 100% line+branch, `mypy` + `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)