### PR TITLE
style: American English across the B1.5c visual surface (color, not colour)

### DIFF
--- a/omni/renderers/context.py
+++ b/omni/renderers/context.py
@@ -13,11 +13,11 @@ the displayed value advances every tick without the card being rebuilt.
 
 `logos` is the optional tile store. When present a renderer blits the team logo;
 when absent (a unit test that doesn't care, a profile too small to fit one) it falls
-back to a plain colour bar — so adding it broke no existing call site.
+back to a plain color bar — so adding it broke no existing call site.
 
-`contrast` is the hardware-tunable legibility policy (the WCAG floor a dim brand colour
+`contrast` is the hardware-tunable legibility policy (the WCAG floor a dim brand color
 is value-lifted to, and the clash distance two tiles must keep). It defaults to the
-pre-policy behaviour, so it too is a transparent addition; a device tunes it per sink.
+pre-policy behavior, so it too is a transparent addition; a device tunes it per sink.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ class RenderContext:
 
     profile: PanelProfile
     now: datetime  # render time; renderers derive live values (e.g. countdowns) from this
-    logos: LogoStore | None = None  # ambient tile store; None -> renderers fall back to a colour bar
+    logos: LogoStore | None = None  # ambient tile store; None -> renderers fall back to a color bar
     contrast: VisualContrastPolicy = DEFAULT_CONTRAST_POLICY  # hw-tunable legibility floor + clash threshold
 
     def __post_init__(self) -> None:

--- a/omni/renderers/live_baseball.py
+++ b/omni/renderers/live_baseball.py
@@ -101,7 +101,7 @@ class LiveBaseballRenderer:
     ) -> None:
         # Top 40px: two team rows (logo + inline R/H/E) on the left, the game-state module on the
         # right. Bottom 24px: the pitcher/batter strip. The logo identifies the team, so the
-        # abbreviation is dropped whenever a tile resolves (kept only as the colour-bar fallback).
+        # abbreviation is dropped whenever a tile resolves (kept only as the color-bar fallback).
         treatment = resolve_matchup_treatment(
             game.away,
             game.home,
@@ -125,7 +125,7 @@ class LiveBaseballRenderer:
         self._batter_pitcher_strip(canvas, payload)
 
     def _draw_mark(self, canvas: Canvas, context: RenderContext, team: Team, side: MarkTreatment) -> None:
-        """Draw the team's mark from its resolved treatment: the logo tile, or the colour-bar fallback.
+        """Draw the team's mark from its resolved treatment: the logo tile, or the color-bar fallback.
 
         The bounds come from the treatment — the same source the win meter derives from — so the tile
         and its gauge are guaranteed to agree, never the 6px drift a separate meter geometry once had.
@@ -180,7 +180,7 @@ class LiveBaseballRenderer:
         pitch = payload.last_pitch
         if pitch is not None:
             # The live pitch rides the right of the batter row — it is what this at-bat is seeing
-            # right now, so it shows bright (not the dim stat grey) and the 4-char type names it.
+            # right now, so it shows bright (not the dim stat gray) and the 4-char type names it.
             draw_right_aligned(canvas, 126, 55, pitch.token, _WHITE, _LABEL_FONT)
 
     @staticmethod

--- a/omni/renderers/visual_treatment.py
+++ b/omni/renderers/visual_treatment.py
@@ -1,6 +1,6 @@
 """The unified visual treatment for a matchup: one source of truth for marks + meter.
 
-A live card draws two team rows, each with a left **mark** (a logo tile or a colour-bar
+A live card draws two team rows, each with a left **mark** (a logo tile or a color-bar
 fallback) and a thin win-probability **meter** hugging that mark. Historically those two
 decisions lived in three places — the clash resolver, the mark renderer, and the meter
 renderer — each re-deriving geometry. They drifted: the meter assumed a tile inset the
@@ -9,7 +9,7 @@ mark renderer didn't use, so a full home gauge could spill into the strip below.
 `MatchupVisualTreatment` resolves the pair **once** per render: each side's logo variant
 (clash-resolved), whether a tile or a bar actually draws, the mark's bounds, and the
 meter's bounds *derived from the mark* (same vertical span, hugging its right edge — so a
-full gauge can never exceed the mark it belongs to). The meter colour is value-lifted
+full gauge can never exceed the mark it belongs to). The meter color is value-lifted
 through a `VisualContrastPolicy`, the one hardware-tunable knob for panel legibility, so a
 brighter diffuser or a dimmer build can raise the floor without touching renderer code.
 """
@@ -44,21 +44,21 @@ _MIN_METER_WIDTH = 1
 
 @dataclass(frozen=True, slots=True)
 class VisualContrastPolicy:
-    """Hardware-tunable legibility thresholds for a matchup's colours on the black panel.
+    """Hardware-tunable legibility thresholds for a matchup's colors on the black panel.
 
     One policy per `DisplaySink`/device (with optional per-profile overrides): a brighter
     diffuser, a dimmer brightness, or a particular matrix batch path can want a higher floor.
-    `min_contrast` is the WCAG ratio a dim brand colour is value-lifted to before it paints a
-    meter; `clash_delta_e` is the CIE76 distance below which two team tiles read as one colour
-    and one side flips to its alt. Defaults reproduce the pre-policy hardcoded behaviour.
+    `min_contrast` is the WCAG ratio a dim brand color is value-lifted to before it paints a
+    meter; `clash_delta_e` is the CIE76 distance below which two team tiles read as one color
+    and one side flips to its alt. Defaults reproduce the pre-policy hardcoded behavior.
     """
 
     min_contrast: float = 3.0
     clash_delta_e: float = 25.0
 
-    def lift(self, colour: RGBColor) -> RGBColor:
-        """Value-lift `colour` to this policy's contrast floor against the black panel."""
-        return colour.value_lifted(min_contrast=self.min_contrast)
+    def lift(self, color: RGBColor) -> RGBColor:
+        """Value-lift `color` to this policy's contrast floor against the black panel."""
+        return color.value_lifted(min_contrast=self.min_contrast)
 
 
 DEFAULT_CONTRAST_POLICY = VisualContrastPolicy()
@@ -84,8 +84,8 @@ class MarkTreatment:
     """One team's resolved treatment: variant, whether a tile draws, and the mark + meter bounds.
 
     `mark` and `meter` come from one derivation — the meter hugs the mark's right edge and shares
-    its vertical span — so a full gauge can never drift past the mark it belongs to. `meter_colour`
-    is the team's *freed* colour (the palette colour of the variant it is NOT showing), already
+    its vertical span — so a full gauge can never drift past the mark it belongs to. `meter_color`
+    is the team's *freed* color (the palette color of the variant it is NOT showing), already
     value-lifted through the contrast policy.
     """
 
@@ -93,7 +93,7 @@ class MarkTreatment:
     is_tile: bool
     mark: Rect
     meter: Rect
-    meter_colour: RGBColor
+    meter_color: RGBColor
 
 
 @dataclass(frozen=True, slots=True)
@@ -109,7 +109,7 @@ class _ProfileGeom:
     """Where a live-card team mark sits for one profile — the single geometry the meter derives from.
 
     `tiles_fit` is False for the single profile, whose 16px rows never fit a 20px tile (it always
-    draws the colour bar). `label_x` is where the score/abbreviation begins; the meter fills the gap
+    draws the color bar). `label_x` is where the score/abbreviation begins; the meter fills the gap
     between the mark's right edge and it.
     """
 
@@ -137,9 +137,9 @@ def _meter_width(gap: int) -> int:
     return max(_MIN_METER_WIDTH, min(_IDEAL_METER_WIDTH, gap))
 
 
-def _freed_colour(team: Team, shown: LogoVariant, policy: VisualContrastPolicy) -> RGBColor:
-    """The value-lifted meter colour for `team`: its *freed* colour (the palette colour of the logo
-    variant it is NOT showing), or its primary when no freed colour is known — lifted via `policy`."""
+def _freed_color(team: Team, shown: LogoVariant, policy: VisualContrastPolicy) -> RGBColor:
+    """The value-lifted meter color for `team`: its *freed* color (the palette color of the logo
+    variant it is NOT showing), or its primary when no freed color is known — lifted via `policy`."""
     freed = team.logo if shown is LogoVariant.ALT else team.logo_alt
     background = freed.preferred_background if freed is not None else None
     return policy.lift(background if background is not None else team.primary_color)
@@ -163,7 +163,7 @@ def _mark_treatment(
         mark = Rect(geom.bar_x, row_top, geom.bar_width, geom.height)
     meter = Rect(mark.right, row_top, _meter_width(geom.label_x - mark.right), geom.height)
     return MarkTreatment(
-        variant=variant, is_tile=is_tile, mark=mark, meter=meter, meter_colour=_freed_colour(team, variant, policy)
+        variant=variant, is_tile=is_tile, mark=mark, meter=meter, meter_color=_freed_color(team, variant, policy)
     )
 
 

--- a/omni/renderers/win_meter.py
+++ b/omni/renderers/win_meter.py
@@ -2,8 +2,8 @@
 
 A live game's win probability is shown the way the reference board shows it — a slim gauge
 next to each club's tile, filled from the bottom in proportion to that side's chance, in the
-team's *freed* colour (value-lifted so even a dim navy reads on the black panel). The gauge's
-bounds **and** colour come from the matchup's :class:`MatchupVisualTreatment`, which derives
+team's *freed* color (value-lifted so even a dim navy reads on the black panel). The gauge's
+bounds **and** color come from the matchup's :class:`MatchupVisualTreatment`, which derives
 the meter from the actual mark — so the gauge can never drift from the mark it hugs (the bug a
 standalone meter geometry once caused, a full home gauge spilling into the strip below).
 """
@@ -22,16 +22,16 @@ def draw_win_meter(canvas: Canvas, treatment: MatchupVisualTreatment, win_probab
     """Draw both teams' win-probability gauges from the resolved matchup treatment.
 
     Each gauge fills from the bottom to its side's win percentage, in that side's treatment
-    colour, within the meter bounds the treatment derived from the mark — so a full gauge spans
+    color, within the meter bounds the treatment derived from the mark — so a full gauge spans
     exactly its mark's height and never spills past it.
     """
-    _gauge(canvas, treatment.away.meter, win_probability.away, treatment.away.meter_colour)
-    _gauge(canvas, treatment.home.meter, win_probability.home, treatment.home.meter_colour)
+    _gauge(canvas, treatment.away.meter, win_probability.away, treatment.away.meter_color)
+    _gauge(canvas, treatment.home.meter, win_probability.home, treatment.home.meter_color)
 
 
-def _gauge(canvas: Canvas, meter: Rect, percent: float, colour: RGBColor) -> None:
+def _gauge(canvas: Canvas, meter: Rect, percent: float, color: RGBColor) -> None:
     fill = round(percent / 100.0 * meter.height)
     if fill <= 0:
         return  # a 0% side shows no bar
     top = meter.y + (meter.height - fill)  # fill from the bottom up
-    canvas.fill_rect(meter.x, top, meter.width, fill, colour)
+    canvas.fill_rect(meter.x, top, meter.width, fill, color)

--- a/tests/test_mlb_palette.py
+++ b/tests/test_mlb_palette.py
@@ -23,7 +23,7 @@ def test_both_palettes_cover_every_team() -> None:
 
 @pytest.mark.parametrize("team_id, info", sorted(_TEAM_ID_INFO.items()))
 def test_palette_matches_the_committed_tiles(team_id: int, info: tuple[str, str]) -> None:
-    # The colour a club's tile actually renders on must equal its palette entry — the
+    # The color a club's tile actually renders on must equal its palette entry — the
     # guard that keeps the runtime maps and the committed art from drifting apart.
     abbr = info[0]
     assert _corner(abbr).pixel(0, 0).delta_e(LOGO_BASE_COLOR[team_id]) < 5
@@ -43,15 +43,15 @@ def test_every_team_has_20x20_base_and_alt_tiles() -> None:
             assert (tile.width, tile.height) == (20, 20)
 
 
-def test_every_meter_colour_value_lifts_to_legibility_on_black() -> None:
-    # The win-probability meter paints a team's freed colour (its base or its alt,
+def test_every_meter_color_value_lifts_to_legibility_on_black() -> None:
+    # The win-probability meter paints a team's freed color (its base or its alt,
     # whichever isn't the logo background) onto the black panel. However dim the brand
-    # colour — the Angels' navy, a deep red — value-lift must clear the legibility floor.
+    # color — the Angels' navy, a deep red — value-lift must clear the legibility floor.
     black = RGBColor(0, 0, 0)
     for palette in (LOGO_BASE_COLOR, LOGO_ALT_COLOR):
-        for team_id, colour in palette.items():
-            lifted = colour.value_lifted()
-            assert lifted.contrast_ratio(black) >= 3.0, f"{_TEAM_ID_INFO[team_id][0]} {colour} did not lift"
+        for team_id, color in palette.items():
+            lifted = color.value_lifted()
+            assert lifted.contrast_ratio(black) >= 3.0, f"{_TEAM_ID_INFO[team_id][0]} {color} did not lift"
 
 
 def test_detrademark_kept_the_twins_c_and_the_athletics_apostrophe() -> None:

--- a/tests/test_visual_treatment.py
+++ b/tests/test_visual_treatment.py
@@ -53,7 +53,7 @@ def test_a_resolved_tile_puts_the_meter_at_the_tiles_right_edge(
 
 
 def test_no_store_falls_back_to_the_bar_and_the_meter_hugs_it() -> None:
-    # Without a logo store the mark is the colour bar, and the meter hugs the *bar* — not the old
+    # Without a logo store the mark is the color bar, and the meter hugs the *bar* — not the old
     # hardcoded tile x=22 that left the gauge floating when only a bar drew.
     t = _treat(COL, LAD, PanelProfile.QUAD_128X64, logos=None, away_top=0, home_top=20)
     assert not t.away.is_tile and (t.away.mark.x, t.away.mark.width) == (0, 4)
@@ -73,20 +73,20 @@ def test_the_meter_stays_within_its_mark_so_a_full_gauge_cannot_clip_the_strip()
     assert t.home.meter.y + t.home.meter.height <= 41
 
 
-def test_each_side_meters_in_its_freed_colour_lifted() -> None:
+def test_each_side_meters_in_its_freed_color_lifted() -> None:
     t = _treat(COL, LAD, PanelProfile.QUAD_128X64, logos=LOGOS, away_top=0, home_top=20)
-    # Neither clashed -> each shows its base tile -> the meter uses its freed (alt) colour, value-lifted.
-    assert t.away.meter_colour == LOGO_ALT_COLOR[115].value_lifted()
-    assert t.home.meter_colour == LOGO_ALT_COLOR[119].value_lifted()
+    # Neither clashed -> each shows its base tile -> the meter uses its freed (alt) color, value-lifted.
+    assert t.away.meter_color == LOGO_ALT_COLOR[115].value_lifted()
+    assert t.home.meter_color == LOGO_ALT_COLOR[119].value_lifted()
 
 
-def test_a_clash_flips_one_side_and_frees_its_base_colour() -> None:
-    # NYY/DET share a cap navy: DET flips to its alt, so its freed colour is its BASE (navy);
+def test_a_clash_flips_one_side_and_frees_its_base_color() -> None:
+    # NYY/DET share a cap navy: DET flips to its alt, so its freed color is its BASE (navy);
     # NYY keeps base, freeing its alt (silver). The two sides agree (one resolve).
     t = _treat(NYY, DET, PanelProfile.QUAD_128X64, logos=LOGOS, away_top=0, home_top=20)
     assert (t.away.variant, t.home.variant) == (LogoVariant.BASE, LogoVariant.ALT)
-    assert t.away.meter_colour == LOGO_ALT_COLOR[147].value_lifted()
-    assert t.home.meter_colour == LOGO_BASE_COLOR[116].value_lifted()
+    assert t.away.meter_color == LOGO_ALT_COLOR[147].value_lifted()
+    assert t.home.meter_color == LOGO_BASE_COLOR[116].value_lifted()
 
 
 @pytest.mark.parametrize("gap, width", [(0, 1), (1, 1), (2, 2), (5, 2)])

--- a/tests/test_win_meter.py
+++ b/tests/test_win_meter.py
@@ -13,15 +13,15 @@ AWAY_C, HOME_C = RGBColor(255, 0, 0), RGBColor(0, 0, 255)
 
 
 def _treatment(away_meter: Rect, home_meter: Rect) -> MatchupVisualTreatment:
-    """A treatment carrying just the two meter bounds + colours the gauge drawer needs."""
+    """A treatment carrying just the two meter bounds + colors the gauge drawer needs."""
 
-    def side(meter: Rect, colour: RGBColor) -> MarkTreatment:
+    def side(meter: Rect, color: RGBColor) -> MarkTreatment:
         return MarkTreatment(
             variant=LogoVariant.BASE,
             is_tile=True,
             mark=Rect(2, meter.y, 20, meter.height),
             meter=meter,
-            meter_colour=colour,
+            meter_color=color,
         )
 
     return MatchupVisualTreatment(away=side(away_meter, AWAY_C), home=side(home_meter, HOME_C))


### PR DESCRIPTION
Adopts the American-English preference on the live-card visual files B1.5c is actively building on, before more code depends on the British spellings.

Mechanical word-swaps (50 lines, balanced): `colour` → `color` — which also renames the freshly-added **`meter_colour` field to `meter_color`**, matching the domain's existing American `RGBColor` / `Team.primary_color` — plus `behaviour` → `behavior` and `grey` → `gray`, across `visual_treatment` / `win_meter` / `context` / `live_baseball` and the palette + treatment + meter tests.

No behavior change, no golden change. 802 tests, `omni/` 100%, mypy + black clean.

The wider inherited codebase still carries British spellings in places; I'll Americanize those files as I touch them rather than in one mass sweep (say the word if you'd prefer a full pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)