### PR TITLE
B1.5c: clock-driven TextLane/MarqueePlan overflow primitive

### DIFF
--- a/omni/renderers/text_lane.py
+++ b/omni/renderers/text_lane.py
@@ -1,0 +1,170 @@
+"""Overflow-safe text lanes: anchored when the text fits, a clock-driven marquee when it doesn't.
+
+A *lane* is a fixed horizontal slot — an x, a width, a baseline-cell top, and a font — that a
+string is drawn into. When the string fits, it is anchored (left, center, or right) and held
+still. When it is wider than the lane, it scrolls horizontally so the whole value can be read
+over time, and only the glyphs that fall wholly inside the lane are drawn — so the scroll
+never spills onto whatever sits beside the lane.
+
+The scroll position is a pure function of the render clock (`RenderContext.now`), not a counter
+the renderer bumps once per frame. A frame-counted scroller advances by however many times the
+render loop happened to fire, so its speed drifts with frame timing and it can jump or stutter;
+deriving the offset from wall-clock time instead means the same instant always yields the same
+frame and the text glides at a fixed pixels-per-second no matter how the loop is paced. One
+cycle dwells at the head (so the start is readable), slides left at a constant rate, dwells at
+the tail (so the end is readable), then repeats — all of it determined by the clock, so nothing
+has to be reset when a card appears or the loop hitches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from omni.core.colors import RGBColor
+from omni.renderers.canvas import Canvas
+from omni.renderers.font import advance
+from omni.renderers.text import draw_centered, draw_right_aligned, text_width
+
+__all__ = [
+    "LaneAnchor",
+    "MarqueeStyle",
+    "MarqueePlan",
+    "TextLane",
+    "DEFAULT_MARQUEE",
+    "draw_text_lane",
+]
+
+
+class LaneAnchor(Enum):
+    """How a string that *fits* its lane is positioned within it (ignored once it marquees)."""
+
+    LEFT = "left"
+    CENTER = "center"
+    RIGHT = "right"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MarqueeStyle:
+    """The tunable feel of a marquee scroll: how fast it slides and how long it pauses at each end.
+
+    Speed is in pixels per second, so the scroll reads at the same rate on any render loop. The
+    dwells give the eye time to catch the start and the end before the cycle repeats.
+    """
+
+    speed_px_per_s: float = 14.0  # a comfortable small-panel read speed
+    start_dwell_s: float = 1.5  # hold at the head before sliding, so the start can be read
+    end_dwell_s: float = 1.5  # hold at the tail before repeating, so the end can be read
+
+    def __post_init__(self) -> None:
+        if self.speed_px_per_s <= 0:
+            raise ValueError("speed_px_per_s must be positive")
+        if self.start_dwell_s < 0 or self.end_dwell_s < 0:
+            raise ValueError("dwell seconds cannot be negative")
+
+
+DEFAULT_MARQUEE = MarqueeStyle()
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MarqueePlan:
+    """The resolved scroll for one overflowing string: its travel distance and its timing.
+
+    ``offset_at`` maps an absolute clock reading to how far left the text is shifted, in pixels —
+    0 at the head, ``distance`` at the tail. It is cyclic and depends only on its argument, so a
+    given instant always produces the same offset (no hidden per-frame state to drift or reset).
+    """
+
+    distance: int  # pixels the text must travel for its tail to reach the lane's right edge
+    style: MarqueeStyle = DEFAULT_MARQUEE
+
+    def __post_init__(self) -> None:
+        if self.distance <= 0:
+            raise ValueError("a marquee plan needs a positive travel distance (the text must overflow)")
+
+    @property
+    def scroll_s(self) -> float:
+        """Seconds the slide itself takes at the style's speed."""
+        return self.distance / self.style.speed_px_per_s
+
+    @property
+    def period_s(self) -> float:
+        """One full cycle: the head dwell, the slide, then the tail dwell."""
+        return self.style.start_dwell_s + self.scroll_s + self.style.end_dwell_s
+
+    def offset_at(self, clock_s: float) -> int:
+        """The leftward pixel shift at absolute time ``clock_s`` (seconds), cycling every period."""
+        t = clock_s % self.period_s
+        if t < self.style.start_dwell_s:
+            return 0  # dwelling at the head — the start is held still and readable
+        t -= self.style.start_dwell_s
+        if t >= self.scroll_s:
+            return self.distance  # dwelling at the tail — the end is held still and readable
+        return min(self.distance, int(t * self.style.speed_px_per_s))  # sliding at a constant rate
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TextLane:
+    """A fixed text slot: a string is drawn into ``[x, x + width)`` with its cell top at ``y``."""
+
+    x: int
+    y: int
+    width: int
+    font: str
+    anchor: LaneAnchor = LaneAnchor.LEFT
+    style: MarqueeStyle = DEFAULT_MARQUEE
+
+    def __post_init__(self) -> None:
+        if self.width <= 0:
+            raise ValueError("a text lane needs a positive width")
+
+    @property
+    def right(self) -> int:
+        """The exclusive right edge of the lane (one past its last pixel)."""
+        return self.x + self.width
+
+
+def draw_text_lane(canvas: Canvas, lane: TextLane, text: str, color: RGBColor, *, now: datetime) -> None:
+    """Draw ``text`` into ``lane``: anchored if it fits, else a clock-driven marquee clipped to the lane."""
+    width = text_width(text, lane.font)
+    if width <= lane.width:
+        _draw_anchored(canvas, lane, text, color)
+        return
+    plan = MarqueePlan(distance=width - lane.width, style=lane.style)
+    visible, vx = _clip_to_lane(text, lane, plan.offset_at(now.timestamp()))
+    if visible:
+        canvas.text(vx, lane.y, visible, color, font=lane.font)
+
+
+def _draw_anchored(canvas: Canvas, lane: TextLane, text: str, color: RGBColor) -> None:
+    """Place a string that fits its lane at the lane's anchor."""
+    if lane.anchor is LaneAnchor.LEFT:
+        canvas.text(lane.x, lane.y, text, color, font=lane.font)
+    elif lane.anchor is LaneAnchor.RIGHT:
+        draw_right_aligned(canvas, lane.right, lane.y, text, color, lane.font)
+    else:  # LaneAnchor.CENTER
+        draw_centered(canvas, lane.x, lane.right, lane.y, text, color, lane.font)
+
+
+def _clip_to_lane(text: str, lane: TextLane, offset: int) -> tuple[str, int]:
+    """The substring whose glyphs fall wholly inside the lane at ``offset``, and its left x.
+
+    Walks glyph advances from the text's shifted left edge and keeps a glyph only if its whole
+    cell lies within ``[lane.x, lane.right)``, so nothing draws past either edge. The kept glyphs
+    are a contiguous run; clipping a contiguous string from both ends can only yield a substring.
+    A lane narrower than its font's glyphs keeps nothing and draws blank rather than spilling.
+    """
+    x = lane.x - offset  # the shifted left edge of the whole string
+    chars: list[str] = []
+    vx = lane.x
+    for ch in text:
+        adv = advance(lane.font, ch)
+        if x >= lane.x and x + adv <= lane.right:
+            if not chars:
+                vx = x  # the first wholly-visible glyph fixes where the run is drawn
+            chars.append(ch)
+        elif chars:
+            break  # the run has passed the lane's right edge; everything after is clipped
+        x += adv
+    return "".join(chars), vx

--- a/tests/test_text_lane.py
+++ b/tests/test_text_lane.py
@@ -1,0 +1,177 @@
+"""Overflow-safe text lanes: clock-driven marquee math, glyph clipping, and anchoring.
+
+The point of the primitive is that the scroll position is a pure function of the render clock,
+so a frame never stutters or resets just because the render loop fired more or fewer times —
+the determinism tests below pin that down.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from omni.core.colors import RGBColor
+from omni.renderers.canvas import RecordingCanvas
+from omni.renderers.text import text_width
+from omni.renderers.text_lane import (
+    DEFAULT_MARQUEE,
+    LaneAnchor,
+    MarqueePlan,
+    MarqueeStyle,
+    TextLane,
+    _clip_to_lane,
+    draw_text_lane,
+)
+
+NOW = datetime(2026, 6, 17, 23, 30, tzinfo=timezone.utc)
+_WHITE = RGBColor(255, 255, 255)
+
+# A style with exact arithmetic so the offset math can be asserted to the pixel.
+_EXACT = MarqueeStyle(speed_px_per_s=10.0, start_dwell_s=2.0, end_dwell_s=3.0)
+_PLAN = MarqueePlan(distance=50, style=_EXACT)  # scroll 5.0s, period 10.0s
+
+
+# --- timing knobs validate their inputs -------------------------------------------------------
+
+
+def test_default_marquee_is_the_zero_arg_style() -> None:
+    assert DEFAULT_MARQUEE == MarqueeStyle()
+
+
+@pytest.mark.parametrize("speed", [0.0, -1.0])
+def test_a_non_positive_speed_is_rejected(speed: float) -> None:
+    with pytest.raises(ValueError, match="speed"):
+        MarqueeStyle(speed_px_per_s=speed)
+
+
+@pytest.mark.parametrize("start, end", [(-1.0, 0.0), (0.0, -1.0)])
+def test_a_negative_dwell_is_rejected(start: float, end: float) -> None:
+    with pytest.raises(ValueError, match="dwell"):
+        MarqueeStyle(start_dwell_s=start, end_dwell_s=end)
+
+
+def test_a_plan_needs_a_positive_distance() -> None:
+    with pytest.raises(ValueError, match="distance"):
+        MarqueePlan(distance=0)
+
+
+def test_a_lane_needs_a_positive_width() -> None:
+    with pytest.raises(ValueError, match="width"):
+        TextLane(x=0, y=0, width=0, font="4x6")
+
+
+# --- the offset is a deterministic, cyclic function of the clock -------------------------------
+
+
+def test_period_and_scroll_durations() -> None:
+    assert (_PLAN.scroll_s, _PLAN.period_s) == (5.0, 10.0)
+
+
+@pytest.mark.parametrize(
+    "clock_s, offset",
+    [
+        (0.0, 0),  # head dwell
+        (1.9, 0),  # still the head dwell
+        (2.0, 0),  # slide begins at the head
+        (3.0, 10),  # 1.0s into the slide at 10px/s
+        (4.0, 20),  # 2.0s in
+        (6.0, 40),  # 4.0s in
+        (7.0, 50),  # slide done -> tail dwell pins to distance
+        (9.9, 50),  # still the tail dwell
+    ],
+)
+def test_offset_walks_dwell_slide_dwell(clock_s: float, offset: int) -> None:
+    assert _PLAN.offset_at(clock_s) == offset
+
+
+def test_offset_is_cyclic_with_the_period() -> None:
+    # Same phase one and two periods later -> identical offset (no drift, no accumulation).
+    assert _PLAN.offset_at(4.0) == _PLAN.offset_at(14.0) == _PLAN.offset_at(24.0) == 20
+
+
+def test_offset_is_monotonic_through_the_slide() -> None:
+    offsets = [_PLAN.offset_at(t) for t in (2.0, 3.0, 4.0, 6.0, 7.0)]
+    assert offsets == sorted(offsets)
+
+
+def test_offset_is_pure_in_its_argument() -> None:
+    # The whole reason for a clock-driven scroll: the same instant always yields the same frame.
+    assert _PLAN.offset_at(3.3) == _PLAN.offset_at(3.3)
+
+
+# --- glyph clipping keeps the run wholly inside the lane ---------------------------------------
+
+
+def test_at_the_head_the_leading_run_is_shown_from_the_lane_left() -> None:
+    lane = TextLane(x=10, y=0, width=20, font="4x6")  # 20px lane fits 5 of the 4px cells
+    visible, vx = _clip_to_lane("ABCDEFGH", lane, offset=0)
+    assert (visible, vx) == ("ABCDE", 10)
+    assert vx >= lane.x and vx + text_width(visible, "4x6") <= lane.right
+
+
+def test_at_the_tail_the_trailing_run_is_flush_to_the_lane_right() -> None:
+    lane = TextLane(x=10, y=0, width=20, font="4x6")
+    distance = text_width("ABCDEFGH", "4x6") - lane.width  # 32 - 20 = 12
+    visible, vx = _clip_to_lane("ABCDEFGH", lane, offset=distance)
+    assert visible == "DEFGH"  # leading glyphs scrolled off the left; loop runs to the end
+    assert vx + text_width(visible, "4x6") == lane.right  # the tail sits flush on the right edge
+
+
+def test_a_lane_narrower_than_a_glyph_keeps_nothing() -> None:
+    lane = TextLane(x=0, y=0, width=3, font="4x6")  # every 4px cell overflows a 3px lane
+    assert _clip_to_lane("AB", lane, offset=0) == ("", 0)
+
+
+# --- draw routing: fit -> anchor, overflow -> clipped marquee ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "anchor, expected_x",
+    [
+        (LaneAnchor.LEFT, 10),  # at the lane's left
+        (LaneAnchor.RIGHT, 30 - 8),  # right edge (x+width=30) minus the 8px string
+        (LaneAnchor.CENTER, 10 + (20 - 8) // 2),  # centered in the 20px lane
+    ],
+)
+def test_text_that_fits_is_anchored_whole(anchor: LaneAnchor, expected_x: int) -> None:
+    lane = TextLane(x=10, y=4, width=20, font="4x6", anchor=anchor)
+    canvas = RecordingCanvas(64, 16)
+    draw_text_lane(canvas, lane, "AB", _WHITE, now=NOW)  # "AB" is 8px, fits the 20px lane
+    ops = canvas.texts()
+    assert len(ops) == 1
+    assert (ops[0].text, ops[0].x, ops[0].y) == ("AB", expected_x, 4)
+
+
+def test_overflow_draws_the_clock_clipped_substring_without_spilling() -> None:
+    lane = TextLane(x=10, y=2, width=20, font="4x6")
+    text = "PITCHER NAME LONG"
+    canvas = RecordingCanvas(64, 16)
+    draw_text_lane(canvas, lane, text, _WHITE, now=NOW)
+
+    # It must draw exactly what the clock-derived offset clips to — no more, no less.
+    plan = MarqueePlan(distance=text_width(text, "4x6") - lane.width)
+    visible, vx = _clip_to_lane(text, lane, plan.offset_at(NOW.timestamp()))
+    ops = canvas.texts()
+    assert len(ops) == 1
+    assert (ops[0].text, ops[0].x, ops[0].y) == (visible, vx, 2)
+    # ...and the drawn run never reaches past either edge of the lane.
+    assert ops[0].x >= lane.x
+    assert ops[0].x + text_width(ops[0].text, lane.font) <= lane.right
+
+
+def test_the_same_clock_redraws_an_identical_frame() -> None:
+    # No hidden per-frame state: rendering twice at one instant cannot drift or reset the scroll.
+    lane = TextLane(x=0, y=0, width=18, font="4x6")
+    text = "A VERY LONG ROSTER LINE"
+    first, second = RecordingCanvas(64, 16), RecordingCanvas(64, 16)
+    draw_text_lane(first, lane, text, _WHITE, now=NOW)
+    draw_text_lane(second, lane, text, _WHITE, now=NOW)
+    assert first.ops == second.ops
+
+
+def test_a_lane_narrower_than_its_glyphs_draws_blank_rather_than_spilling() -> None:
+    lane = TextLane(x=0, y=0, width=3, font="4x6")  # forces overflow, but nothing fits
+    canvas = RecordingCanvas(64, 16)
+    draw_text_lane(canvas, lane, "AB", _WHITE, now=NOW)
+    assert canvas.texts() == []


### PR DESCRIPTION
## What

Adds `omni/renderers/text_lane.py` — an **overflow-safe text lane**. A string is anchored (left/center/right) when it fits its lane and **marquees** when it doesn't, with only the glyphs that fall **wholly inside** the lane drawn, so a scroll never spills onto whatever sits beside the lane.

This is the **B1.5c·2** closeout item from the round-3 verdict ("add overflow-safe text lanes before more density"). It lands the **primitive only** — wiring the pitch token + roster lines onto lanes is **B1.5c·3**, where the layout change carries a golden.

## Why clock-driven

The legacy board's `scrollingtext.render_text` advanced the scroll position **once per `run_once`**, so its speed drifted with frame timing and it could jump/stutter — the clock-sync jitter the visual review flagged.

`MarqueePlan.offset_at(clock_s)` is a **pure function of the render clock** (`RenderContext.now`):

- identical instant → identical frame (a marquee that **cannot reset on a loop hitch** — appliance-bundle item 6),
- fixed **pixels-per-second** glide regardless of how the render loop is paced,
- one cycle **dwells at the head → slides → dwells at the tail → repeats**, all clock-derived (deterministic start/end positions + dwell + repeat, per the directive).

## API

- `MarqueeStyle` — tunable `speed_px_per_s` / `start_dwell_s` / `end_dwell_s` (validated).
- `MarqueePlan(distance, style)` — `offset_at(clock_s) -> int`, cyclic, 0 at the head … `distance` at the tail.
- `TextLane(x, y, width, font, anchor, style)` — the slot; `LaneAnchor` ∈ {LEFT, CENTER, RIGHT}.
- `draw_text_lane(canvas, lane, text, color, *, now)` — fit → anchored; overflow → clipped marquee.

Glyph clipping keeps the visible run wholly inside `[x, x+width)` (a lane narrower than its font's glyphs draws blank rather than spilling). The marquee emits a single clean `text` op, so it stays assertable in the `RecordingCanvas` idiom.

## Tests / gate

- `tests/test_text_lane.py` (28 cases): dwell→slide→dwell offset math, cyclicity, monotonicity, purity (same clock → identical frame), head/tail glyph clipping, no-spill, and all three anchors.
- Full suite **830 passed**, 24 subtests; **100% line+branch** on `omni/` maintained; black + mypy clean.

No renderer call sites change yet, so **no goldens move** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)