### PR TITLE
tooling: 6x golden contact sheet (auto on regen + manual CLI)

### DIFF
--- a/omni/preview/contact_sheet.py
+++ b/omni/preview/contact_sheet.py
@@ -1,0 +1,75 @@
+"""Stitch rendered panels into one contact sheet for eyeball review.
+
+The committed goldens are 1 LED = 1 px so they diff exactly, but that makes a 128x64
+PNG miserable to review — you end up zooming an image viewer into each one. This
+composes a directory of them into a single sheet at a review scale (default 6x,
+nearest-neighbor so the LEDs stay crisp squares), each panel labeled, so the whole
+batch reads at a glance. It is a *review* artifact only; the committed goldens stay
+1:1 for exact comparison.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+__all__ = ["build_contact_sheet", "write_contact_sheet"]
+
+_BG = (28, 28, 30)  # a dark sheet so even all-black panels sit on a visible field
+_LABEL_COLOR = (220, 220, 220)
+_BORDER = (90, 90, 95)  # frames each panel so a black-background card is still bounded
+_PAD = 8
+_LABEL_H = 14  # headroom above each panel for its name
+
+
+def build_contact_sheet(panels: list[tuple[str, Image.Image]], *, scale: int = 6, columns: int = 4) -> Image.Image:
+    """Compose ``(label, image)`` panels into a labeled grid, each image scaled ``scale`` x.
+
+    Cells are uniform (sized to the largest panel) and images are centered within them, so a
+    mix of profiles (128x64, 64x64, 64x32) lines up. Nearest-neighbor keeps every LED a crisp
+    square at the review scale.
+    """
+    if not panels:
+        raise ValueError("no panels to compose")
+    scaled = [
+        (label, img.resize((img.width * scale, img.height * scale), Image.Resampling.NEAREST)) for label, img in panels
+    ]
+    cell_w = max(img.width for _, img in scaled)
+    cell_h = max(img.height for _, img in scaled)
+    col_w, row_h = cell_w + 2 * _PAD, cell_h + _LABEL_H + 2 * _PAD
+    rows = -(-len(scaled) // columns)  # ceil division
+    sheet = Image.new("RGB", (columns * col_w, rows * row_h), _BG)
+    draw = ImageDraw.Draw(sheet)
+    font = ImageFont.load_default()
+    for i, (label, img) in enumerate(scaled):
+        row, col = divmod(i, columns)
+        ox, oy = col * col_w + _PAD, row * row_h + _PAD
+        draw.text((ox, oy), label, fill=_LABEL_COLOR, font=font)
+        ix = ox + (cell_w - img.width) // 2  # center a narrower panel in its cell
+        iy = oy + _LABEL_H
+        sheet.paste(img, (ix, iy))
+        draw.rectangle((ix - 1, iy - 1, ix + img.width, iy + img.height), outline=_BORDER)
+    return sheet
+
+
+def write_contact_sheet(
+    src_dir: Path | str, out_path: Path | str, *, scale: int = 6, columns: int = 4, pattern: str = "*.png"
+) -> int:
+    """Load every ``pattern`` image under ``src_dir`` (skipping ``_``-prefixed names), stitch, and save.
+
+    Returns the panel count. ``_``-prefixed files are skipped so a sheet written into the same
+    directory is never folded back into the next one.
+    """
+    src, out = Path(src_dir), Path(out_path)
+    paths = sorted(p for p in src.glob(pattern) if not p.name.startswith("_"))
+    if not paths:
+        raise FileNotFoundError(f"no {pattern} images under {src}")
+    panels = []
+    for path in paths:
+        with Image.open(path) as handle:  # close each source handle; the converted copy lives on
+            panels.append((path.stem, handle.convert("RGB")))
+    sheet = build_contact_sheet(panels, scale=scale, columns=columns)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(out)
+    return len(panels)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared pytest hooks.
+
+When the goldens are (re)generated (``OMNI_REGEN_GOLDEN=1``), stitch them into one 6x review
+sheet so the whole batch can be eyeballed at once instead of zooming an image viewer into each
+128x64 PNG. The sheet lands at ``build/golden_contact_sheet.png`` (git-ignored); it is a review
+artifact only — the committed goldens stay 1 LED = 1 px so they diff exactly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from omni.preview.contact_sheet import write_contact_sheet
+
+_GOLDEN_DIR = Path(__file__).parent / "golden"
+_SHEET = Path(__file__).parent.parent / "build" / "golden_contact_sheet.png"
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if not os.environ.get("OMNI_REGEN_GOLDEN"):
+        return  # only after an intentional golden regen, never on an ordinary run
+    count = write_contact_sheet(_GOLDEN_DIR, _SHEET, scale=6)
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_line(f"[golden] contact sheet: {_SHEET} ({count} panels at 6x)")

--- a/tests/test_preview_contact_sheet.py
+++ b/tests/test_preview_contact_sheet.py
@@ -1,0 +1,49 @@
+"""The golden contact sheet: grid sizing, row wrap, and directory stitching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from omni.preview.contact_sheet import build_contact_sheet, write_contact_sheet
+
+_PAD, _LABEL_H = 8, 14  # mirror the module's cell padding so the size math is checkable here
+
+
+def test_grid_is_sized_to_the_largest_panel() -> None:
+    # A mix of profiles shares one uniform cell sized to the widest/tallest, so they line up.
+    panels = [("wide", Image.new("RGB", (128, 64))), ("narrow", Image.new("RGB", (64, 32), (9, 9, 9)))]
+    sheet = build_contact_sheet(panels, scale=6, columns=2)
+    assert sheet.size == (2 * (128 * 6 + 2 * _PAD), 64 * 6 + _LABEL_H + 2 * _PAD)
+
+
+def test_panels_wrap_onto_multiple_rows() -> None:
+    panels = [(f"p{i}", Image.new("RGB", (64, 32))) for i in range(3)]
+    sheet = build_contact_sheet(panels, scale=2, columns=2)  # 3 panels, 2 columns -> 2 rows
+    assert sheet.height == 2 * (32 * 2 + _LABEL_H + 2 * _PAD)
+
+
+def test_empty_panel_list_is_rejected() -> None:
+    with pytest.raises(ValueError, match="no panels"):
+        build_contact_sheet([], scale=6)
+
+
+def test_write_stitches_a_directory_and_skips_underscored(tmp_path: Path) -> None:
+    golden = tmp_path / "golden"
+    golden.mkdir()
+    Image.new("RGB", (128, 64), (1, 2, 3)).save(golden / "b.png")
+    Image.new("RGB", (64, 64), (4, 5, 6)).save(golden / "a.png")
+    Image.new("RGB", (8, 8)).save(golden / "_prior_sheet.png")  # underscored -> never folded back in
+    out = tmp_path / "build" / "sheet.png"
+    count = write_contact_sheet(golden, out, scale=3, columns=2)
+    assert count == 2  # the two goldens, not the underscored prior sheet
+    assert out.exists()
+    with Image.open(out) as sheet:
+        assert sheet.size[0] > 0
+
+
+def test_write_raises_when_no_images_match(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="no"):
+        write_contact_sheet(tmp_path, tmp_path / "out.png")

--- a/tools/golden_contact_sheet.py
+++ b/tools/golden_contact_sheet.py
@@ -1,0 +1,36 @@
+"""Stitch the committed goldens into one contact sheet for review.
+
+    python tools/golden_contact_sheet.py [--scale 6] [--columns 4] [--pattern 'live_baseball_*.png']
+
+The committed goldens stay 1 LED = 1 px so they diff exactly; this is a *review* view only,
+nearest-neighbor upscaled (default 6x) so the LEDs read as crisp squares instead of a 128x64
+smudge you have to zoom into. The same sheet is written automatically after a golden regen
+(``OMNI_REGEN_GOLDEN=1 pytest -k golden`` -> ``build/golden_contact_sheet.png``; see
+tests/conftest.py). Pass ``--pattern`` to focus on one card family.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from omni.preview.contact_sheet import write_contact_sheet
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Stitch the golden images into a 6x contact sheet.")
+    parser.add_argument("--golden-dir", type=Path, default=_ROOT / "tests" / "golden")
+    parser.add_argument("--out", type=Path, default=_ROOT / "build" / "golden_contact_sheet.png")
+    parser.add_argument("--scale", type=int, default=6, help="LED -> pixel review scale (default 6)")
+    parser.add_argument("--columns", type=int, default=4)
+    parser.add_argument("--pattern", default="*.png", help="filter, e.g. 'live_baseball_*.png'")
+    args = parser.parse_args()
+    count = write_contact_sheet(args.golden_dir, args.out, scale=args.scale, columns=args.columns, pattern=args.pattern)
+    print(f"wrote {args.out} ({count} panels at {args.scale}x)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Reviewing a layout meant opening 128×64 golden PNGs one at a time and zooming an image viewer to make out the LEDs. This stitches the goldens into **one labeled sheet at a review scale** (default **6× nearest-neighbor**, so each LED stays a crisp square) — the whole batch reads at a glance.

The committed goldens stay **1 LED = 1 px** (so they diff exactly); the sheet is a **review artifact only** (`build/`, git-ignored).

## What

- **`omni/preview/contact_sheet.py`** — `build_contact_sheet` (pure grid composition: uniform cells sized to the largest panel, narrower profiles centered) + `write_contact_sheet` (stitch a directory of PNGs, skipping `_`-prefixed names).
- **`tests/conftest.py`** — a `sessionfinish` hook writes `build/golden_contact_sheet.png` whenever `OMNI_REGEN_GOLDEN` is set. **Making the batch makes the sheet** — no extra step.
- **`tools/golden_contact_sheet.py`** — a manual CLI for an on-demand or per-family sheet without re-rendering:
  ```
  python tools/golden_contact_sheet.py --pattern 'live_baseball_*.png' --scale 6
  ```

## Verified

- Auto-emit fired on `OMNI_REGEN_GOLDEN=1 pytest -k golden`: wrote the full 26-panel sheet (3136×2898 at 6×), goldens byte-unchanged (no churn).
- **835 passed**, 24 subtests · **100% line+branch** on the new module · black + mypy clean.

## Note

`build/` is already git-ignored. Independent of #87 — pure tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)