### PR TITLE
fix(tools): contact-sheet CLI importable when run directly

### DIFF
--- a/tools/golden_contact_sheet.py
+++ b/tools/golden_contact_sheet.py
@@ -12,11 +12,13 @@ tests/conftest.py). Pass ``--pattern`` to focus on one card family.
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
-from omni.preview.contact_sheet import write_contact_sheet
-
 _ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))  # so `omni` resolves when this script is run directly, not just under pytest
+
+from omni.preview.contact_sheet import write_contact_sheet
 
 
 def main() -> int:


### PR DESCRIPTION
Running `python tools/golden_contact_sheet.py` puts `tools/` on `sys.path` (not the repo root), so `import omni` failed with `ModuleNotFoundError`. The pytest auto-emit hook was unaffected (pytest adds the root). Insert the repo root on `sys.path` before the import so the manual CLI works from anywhere.

Verified: `python tools/golden_contact_sheet.py --pattern 'live_baseball_win_meter_*.png'` now writes the sheet. mypy + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)