### PR TITLE
fonts: register the full committed BDF set

### DIFF
--- a/omni/renderers/font.py
+++ b/omni/renderers/font.py
@@ -1,8 +1,10 @@
 """BDF font rasterization for the Pillow canvas.
 
 Uses the repo's committed patched BDF fonts via `bdfparser`, so glyph rendering is
-deterministic and golden images are stable. Only fixed-width fonts are registered,
-so character advance is a constant cell width.
+deterministic and golden images are stable. The whole committed set is registered (so
+nothing we ship is forgotten); each entry's width/height is its BDF bounding box. Almost
+all are fixed-width — `advance` reads each glyph's real DWIDTH, so even the one proportional
+face (helvR12) measures correctly, while the fixed faces advance by their constant cell.
 """
 
 from __future__ import annotations
@@ -26,9 +28,36 @@ class FontSpec:
     height: int
 
 
+# Every committed BDF, registered by its filename stem so it can be named from a renderer.
+# Standard X11 faces are named WxH (with -B bold / -O oblique siblings at the same cell); the
+# rest carry their own names. helvR12 is proportional (the dims are its bounding box).
 FONTS: dict[str, FontSpec] = {
+    "tom-thumb": FontSpec("tom-thumb", 3, 6),
     "4x6": FontSpec("4x6", 4, 6),
+    "4x6-legacy": FontSpec("4x6-legacy", 4, 6),
+    "5x7": FontSpec("5x7", 5, 7),
+    "5x8": FontSpec("5x8", 5, 8),
+    "6x9": FontSpec("6x9", 6, 9),
     "6x10": FontSpec("6x10", 6, 10),
+    "6x12": FontSpec("6x12", 6, 12),
+    "clR6x12": FontSpec("clR6x12", 6, 12),
+    "6x13": FontSpec("6x13", 6, 13),
+    "6x13B": FontSpec("6x13B", 6, 13),
+    "6x13O": FontSpec("6x13O", 6, 13),
+    "7x13": FontSpec("7x13", 7, 13),
+    "7x13B": FontSpec("7x13B", 7, 13),
+    "7x13O": FontSpec("7x13O", 7, 13),
+    "7x14": FontSpec("7x14", 7, 14),
+    "7x14B": FontSpec("7x14B", 7, 14),
+    "8x13": FontSpec("8x13", 8, 13),
+    "8x13B": FontSpec("8x13B", 8, 13),
+    "8x13O": FontSpec("8x13O", 8, 13),
+    "helvR12": FontSpec("helvR12", 14, 15),
+    "9x15": FontSpec("9x15", 9, 15),
+    "9x15B": FontSpec("9x15B", 9, 15),
+    "9x18": FontSpec("9x18", 9, 18),
+    "9x18B": FontSpec("9x18B", 9, 18),
+    "10x20": FontSpec("10x20", 10, 20),
 }
 
 
@@ -39,7 +68,7 @@ def _load(name: str) -> Any:  # Any: bdfparser ships no type stubs
 
 
 def char_size(name: str) -> tuple[int, int]:
-    """The fixed (width, height) cell of a registered font, in pixels."""
+    """The (width, height) bounding-box cell of a registered font, in pixels."""
     spec = FONTS[name]
     return spec.width, spec.height
 

--- a/tests/test_renderer_font.py
+++ b/tests/test_renderer_font.py
@@ -8,10 +8,22 @@ A named ``THIN_SPACE`` constant isolates U+2009 so the rest of the source stays 
 
 from __future__ import annotations
 
-from omni.renderers.font import advance, rasterize
+import pytest
+
+from omni.renderers.font import FONTS, advance, char_size, rasterize
 
 THIN_SPACE = " "
 ONE_HALF = "½"
+
+
+@pytest.mark.parametrize("name", sorted(FONTS))
+def test_every_registered_font_loads_and_reports_sane_metrics(name: str) -> None:
+    # Each committed font must load through bdfparser and rasterize without error and report a
+    # positive cell + advance, so a registry typo or a missing .bdf fails loudly right here.
+    width, height = char_size(name)
+    assert width > 0 and height > 0
+    assert len(rasterize(name, "Ag5 0")) > 0
+    assert advance(name, "0") > 0
 
 
 def test_advance_is_the_cell_width_for_ordinary_glyphs() -> None:


### PR DESCRIPTION
## What

We ship **26 patched BDF fonts** in `assets/fonts/patched/` but only `4x6` and `6x10` were registered in `FONTS`, so the rest (9x18B, 6x13, 5x7, 7x13, 8x13, 10x20, …) were invisible to renderers. Register them all by filename stem, each entry's `(width, height)` taken from its **BDF bounding box**.

> Per your "register all the font sizes so we don't forget we have em."

## Notes

- Standard X11 faces are `WxH` with `-B`/`-O` bold/oblique siblings at the same cell.
- `helvR12` is **proportional** (dims = its 14×15 bounding box); `advance()` already reads each glyph's real `DWIDTH`, so text measures correctly regardless.
- A **parametrized test** loads + rasterizes every registered font, so a registry typo or a missing `.bdf` fails loudly here, not at render time.

## Gate

863 passed · **100% line+branch** on `omni/` · black + mypy clean. No renders change (pure registry addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)